### PR TITLE
gbn+cmd: fix gbn race conditions

### DIFF
--- a/cmd/basicClient/main.go
+++ b/cmd/basicClient/main.go
@@ -58,7 +58,7 @@ func main() {
 
 func chatWithLND(c mockrpc.MockServiceClient) error {
 
-	largeResp := make([]byte, 1024*1024*4)
+	largeResp := make([]byte, 1024*4)
 	rand.Read(largeResp)
 	req := &mockrpc.Request{Req: largeResp}
 
@@ -70,7 +70,6 @@ func chatWithLND(c mockrpc.MockServiceClient) error {
 		}
 
 		fmt.Println("got the thing", time.Since(t))
-		time.Sleep(5 * time.Second)
 	}
 
 	return nil


### PR DESCRIPTION
This commit ensures that reading and writing of the remoteClosed
variable is safe. It also fixes some race conditions in the gbn tests.