### PR TITLE
mailbox: use scrypt to stretch passphrase before usage in Noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GOLIST := go list $(PKG)/... | grep -v '/vendor/'
 XARGS := xargs -L 1
 
-UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
+UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="rpctest $(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
 UNIT_RACE := $(UNIT) -race
 
 LDFLAGS := -s -w -buildid=

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lightninglabs/terminal-connect
 require (
 	github.com/btcsuite/btcd v0.21.0-beta.0.20210513141527-ee5896bad5be
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
+	github.com/btcsuite/btcwallet v0.12.1-0.20210519225359-6ab9b615576f
 	github.com/go-errors/errors v1.0.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/kkdai/bstream v0.0.0-20181106074824-b3251f7901ec

--- a/mailbox/crypto_rpctest.go
+++ b/mailbox/crypto_rpctest.go
@@ -1,0 +1,14 @@
+//go:build rpctest
+// +build rpctest
+
+package mailbox
+
+import "github.com/btcsuite/btcwallet/waddrmgr"
+
+func init() {
+	// For the purposes of our itest and unit tests, we'll crank down the
+	// scrypt params a bit.
+	scryptN = waddrmgr.FastScryptOptions.N
+	scryptR = waddrmgr.FastScryptOptions.R
+	scryptP = waddrmgr.FastScryptOptions.P
+}

--- a/mailbox/server.go
+++ b/mailbox/server.go
@@ -75,8 +75,6 @@ func (s *Server) Accept() (net.Conn, error) {
 		}
 	}
 
-	log.Debugf("new conn entering")
-
 	receiveSID := GetSID(s.sid, false)
 	sendSID := GetSID(s.sid, true)
 
@@ -98,8 +96,6 @@ func (s *Server) Accept() (net.Conn, error) {
 			return nil, err
 		}
 	}
-
-	log.Debugf("new conn succeeded")
 
 	return s.mailboxConn, nil
 }

--- a/mailbox/tcp_noise_conn.go
+++ b/mailbox/tcp_noise_conn.go
@@ -44,9 +44,14 @@ func Dial(localPriv keychain.SingleKeyECDH, netAddr net.Addr, passphrase []byte,
 		return nil, err
 	}
 
+	noise, err := NewBrontideMachine(true, localPriv, passphrase)
+	if err != nil {
+		return nil, err
+	}
+
 	b := &NoiseConn{
 		conn:  conn,
-		noise: NewBrontideMachine(true, localPriv, passphrase),
+		noise: noise,
 	}
 
 	// Initiate the handshake by sending the first act to the receiver.


### PR DESCRIPTION
In this commit, we start to use scrypt to stretch the passphrase in
order to obtain additional entropy and also mitigate brute force attacks
somewhat.

Note that we do this within `NewBrontideMachine` as this ensures that
we're able to throttle _each_ new authentication attempt.

Thinking about this change a bit more after it was written: I think we instead just want to use `HKDF` to generate both the 32-byte value we use to create the point as well as the mailbox ID. Typically you use something like scrypt when you don't know the entropy of the generated password. However in our case (with the default client at least), we always generate it ourselves and know it to be high entropy. 