### PR TITLE
mailbox: dynamic auth data size

### DIFF
--- a/mailbox/noise.go
+++ b/mailbox/noise.go
@@ -384,6 +384,18 @@ type Machine struct {
 
 	handshakeState
 
+	// minHandshakeVersion is the minimum handshake version that the Machine
+	// supports.
+	minHandshakeVersion byte
+
+	// maxHandshakeVersion is the maximum handshake version that the Machine
+	// supports.
+	maxHandshakeVersion byte
+
+	// handshakeVersion is handshake version that the client and server have
+	// agreed on.
+	handshakeVersion byte
+
 	// nextCipherHeader is a static buffer that we'll use to read in the
 	// next ciphertext header from the wire. The header is a 2 byte length
 	// (of the next ciphertext), followed by a 16 byte MAC.
@@ -419,7 +431,8 @@ type Machine struct {
 // arguments for adding additional options to the brontide Machine
 // initialization.
 func NewBrontideMachine(initiator bool, localPub keychain.SingleKeyECDH,
-	passphrase []byte, options ...func(*Machine)) (*Machine, error) {
+	passphrase []byte, minVersion, maxVersion byte,
+	options ...func(*Machine)) (*Machine, error) {
 
 	handshake := newHandshakeState(
 		initiator, lightningNodeConnectPrologue, localPub,
@@ -434,9 +447,12 @@ func NewBrontideMachine(initiator bool, localPub keychain.SingleKeyECDH,
 	}
 
 	m := &Machine{
-		handshakeState: handshake,
-		ephemeralGen:   ephemeralGen,
-		password:       password,
+		handshakeState:      handshake,
+		ephemeralGen:        ephemeralGen,
+		password:            password,
+		minHandshakeVersion: minVersion,
+		maxHandshakeVersion: maxVersion,
+		handshakeVersion:    maxVersion,
 	}
 
 	// With the default options established, we'll now process all the
@@ -489,10 +505,19 @@ func ekeUnmask(me *btcec.PublicKey, password []byte) *btcec.PublicKey {
 }
 
 const (
-	// HandshakeVersion is the expected version of the brontide handshake.
-	// Any messages that carry a different version will cause the handshake
+	// HandshakeVersion0 is the handshake version in which the authData is
+	// sent in act 2.
+	HandshakeVersion0 = byte(0)
+
+	// MinHandshakeVersion is the minimum handshake version that is
+	// currently supported.
+	MinHandshakeVersion = HandshakeVersion0
+
+	// MaxHandshakeVersion is the maximum handshake that we currently
+	// support. Any messages that carry a version not between
+	// MinHandshakeVersion and MaxHandshakeVersion will cause the handshake
 	// to abort immediately.
-	HandshakeVersion = byte(0)
+	MaxHandshakeVersion = HandshakeVersion0
 
 	// ActOneSize is the size of the packet sent from initiator to
 	// responder in ActOne. The packet consists of a handshake version, an
@@ -558,7 +583,9 @@ func (b *Machine) GenActOne() ([ActOneSize]byte, error) {
 
 	authPayload := b.EncryptAndHash([]byte{})
 
-	actOne[0] = HandshakeVersion
+	// The initiator sends the minimum handshake version that it will
+	//  accept.
+	actOne[0] = b.minHandshakeVersion
 	copy(actOne[1:34], maskedEphemeralBytes)
 	copy(actOne[34:], authPayload)
 
@@ -580,14 +607,15 @@ func (b *Machine) RecvActOne(actOne [ActOneSize]byte) error {
 	)
 
 	// If the handshake version is unknown, then the handshake fails
-	// immediately.
-	//
-	// TODO(roasbeef); use version to gate the initial and subsequent
-	// pairings
-	if actOne[0] != HandshakeVersion {
+	// immediately. If the handshake version is unknown or no longer
+	// supported, then the handshake fails immediately.
+	if actOne[0] < b.minHandshakeVersion ||
+		actOne[0] > b.maxHandshakeVersion {
+
 		return fmt.Errorf("act one: invalid handshake version: %v, "+
-			"only %v is valid, msg=%x", actOne[0], HandshakeVersion,
-			actOne[:])
+			"only versions between %v and %v are valid, msg=%x",
+			actOne[0], b.minHandshakeVersion,
+			b.maxHandshakeVersion, actOne[:])
 	}
 
 	copy(e[:], actOne[1:34])
@@ -685,7 +713,10 @@ func (b *Machine) GenActTwo() ([ActTwoSize]byte, error) {
 
 	authPayload := b.EncryptAndHash(payload[:])
 
-	actTwo[0] = HandshakeVersion
+	// The responder will always send its preferred handshake version in
+	// the hopes that the initiator will then upgrade to this version in
+	// act 3.
+	actTwo[0] = b.handshakeVersion
 	copy(actTwo[1:34], ephemeral)
 	copy(actTwo[34:], ciphertext)
 	copy(actTwo[83:], authPayload)
@@ -707,11 +738,19 @@ func (b *Machine) RecvActTwo(actTwo [ActTwoSize]byte) error {
 
 	// If the handshake version is unknown, then the handshake fails
 	// immediately.
-	if actTwo[0] != HandshakeVersion {
+	responderVersion := actTwo[0]
+	if responderVersion < b.minHandshakeVersion ||
+		responderVersion > b.maxHandshakeVersion {
+
 		return fmt.Errorf("act two: invalid handshake version: %v, "+
-			"only %v is valid, msg=%x", actTwo[0], HandshakeVersion,
-			actTwo[:])
+			"only versions between %v and %v are valid, msg=%x",
+			responderVersion, b.minHandshakeVersion,
+			b.maxHandshakeVersion, actTwo[:])
 	}
+
+	// The version that the responder sent over is the latest version that
+	// they support, so we will continue with this version.
+	b.handshakeVersion = responderVersion
 
 	copy(e[:], actTwo[1:34])
 	copy(s[:], actTwo[34:83])
@@ -795,7 +834,7 @@ func (b *Machine) GenActThree() ([ActThreeSize]byte, error) {
 
 	authPayload := b.EncryptAndHash([]byte{})
 
-	actThree[0] = HandshakeVersion
+	actThree[0] = b.handshakeVersion
 	copy(actThree[1:50], ciphertext)
 	copy(actThree[50:], authPayload)
 
@@ -818,11 +857,12 @@ func (b *Machine) RecvActThree(actThree [ActThreeSize]byte) error {
 	)
 
 	// If the handshake version is unknown, then the handshake fails
-	// immediately.
-	if actThree[0] != HandshakeVersion {
+	// immediately. At this point, we expect the initiator to agree with
+	// our current handshake version that we sent over in act 2.
+	if actThree[0] != b.handshakeVersion {
 		return fmt.Errorf("act three: invalid handshake version: %v, "+
-			"only %v is valid, msg=%x", actThree[0], HandshakeVersion,
-			actThree[:])
+			"only %v is valid, msg=%x", actThree[0],
+			b.maxHandshakeVersion, actThree[:])
 	}
 
 	copy(s[:], actThree[1:33+16+1])

--- a/mailbox/noise_test.go
+++ b/mailbox/noise_test.go
@@ -1,14 +1,19 @@
 package mailbox
 
 import (
+	"bytes"
+	"context"
 	"crypto/sha256"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSpake2Mask tests the masking operation for SPAK2 to ensure that ti's
+// TestSpake2Mask tests the masking operation for SPAKE2 to ensure that ti's
 // properly reverseable.
 func TestSpake2Mask(t *testing.T) {
 	t.Parallel()
@@ -26,4 +31,123 @@ func TestSpake2Mask(t *testing.T) {
 
 	unmaskedPoint := ekeUnmask(maskedPoint, passHash[:])
 	require.True(t, unmaskedPoint.IsEqual(pub))
+}
+
+// TestHandshake tests that client and server are able successfully perform
+// a handshake.
+func TestHandshake(t *testing.T) {
+	tests := []struct {
+		name             string
+		serverMinVersion byte
+		serverMaxVersion byte
+		clientMinVersion byte
+		clientMaxVersion byte
+		authData         []byte
+	}{
+		{
+			name:             "server v0 and client v0",
+			serverMinVersion: HandshakeVersion0,
+			serverMaxVersion: HandshakeVersion0,
+			clientMinVersion: HandshakeVersion0,
+			clientMaxVersion: HandshakeVersion0,
+			authData:         []byte{0, 1, 2, 3},
+		},
+	}
+
+	pk1, err := btcec.NewPrivateKey(btcec.S256())
+	require.NoError(t, err)
+
+	pk2, err := btcec.NewPrivateKey(btcec.S256())
+	require.NoError(t, err)
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			server := NewNoiseGrpcConn(
+				&keychain.PrivKeyECDH{PrivKey: pk1},
+				test.authData, pass,
+				WithMinHandshakeVersion(test.serverMinVersion),
+				WithMaxHandshakeVersion(test.serverMaxVersion),
+			)
+
+			client := NewNoiseGrpcConn(
+				&keychain.PrivKeyECDH{PrivKey: pk2}, nil, pass,
+				WithMinHandshakeVersion(test.clientMinVersion),
+				WithMaxHandshakeVersion(test.clientMaxVersion),
+			)
+
+			conn1, conn2 := newMockProxyConns()
+			defer func() {
+				conn1.Close()
+				conn2.Close()
+			}()
+
+			var (
+				serverConn net.Conn
+			)
+			serverErrChan := make(chan error)
+			go func() {
+				var err error
+				serverConn, _, err = server.ServerHandshake(
+					conn1,
+				)
+				serverErrChan <- err
+			}()
+
+			clientConn, _, err := client.ClientHandshake(
+				context.Background(), "", conn2,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case err := <-serverErrChan:
+				if err != nil {
+					t.Fatal(err)
+				}
+
+			case <-time.After(time.Second):
+				t.Fatalf("handshake timeout")
+			}
+
+			// Ensure that any auth data was successfully received
+			// by the client.
+			require.True(
+				t, bytes.Equal(client.authData, test.authData),
+			)
+
+			// Check that messages can be sent between client and
+			// server normally now.
+			testMessage := []byte("test message")
+			go func() {
+				_, err := clientConn.Write(testMessage)
+				require.NoError(t, err)
+			}()
+
+			recvBuffer := make([]byte, len(testMessage))
+			_, err = serverConn.Read(recvBuffer)
+			require.NoError(t, err)
+			require.True(t, bytes.Equal(recvBuffer, testMessage))
+		})
+	}
+}
+
+var _ ProxyConn = (*mockProxyConn)(nil)
+
+type mockProxyConn struct {
+	net.Conn
+}
+
+func (m *mockProxyConn) ReceiveControlMsg(_ ControlMsg) error {
+	return nil
+}
+
+func (m *mockProxyConn) SendControlMsg(_ ControlMsg) error {
+	return nil
+}
+
+func newMockProxyConns() (*mockProxyConn, *mockProxyConn) {
+	c1, c2 := net.Pipe()
+	return &mockProxyConn{c1}, &mockProxyConn{c2}
 }

--- a/mailbox/noise_test.go
+++ b/mailbox/noise_test.go
@@ -3,6 +3,7 @@ package mailbox
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"net"
 	"testing"
@@ -36,6 +37,10 @@ func TestSpake2Mask(t *testing.T) {
 // TestHandshake tests that client and server are able successfully perform
 // a handshake.
 func TestHandshake(t *testing.T) {
+	largeAuthData := make([]byte, 3*1024*1024)
+	_, err := rand.Read(largeAuthData)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name             string
 		serverMinVersion byte
@@ -51,6 +56,45 @@ func TestHandshake(t *testing.T) {
 			clientMinVersion: HandshakeVersion0,
 			clientMaxVersion: HandshakeVersion0,
 			authData:         []byte{0, 1, 2, 3},
+		},
+		{
+			name:             "server v1 and client v1 no auth",
+			serverMinVersion: HandshakeVersion1,
+			serverMaxVersion: HandshakeVersion1,
+			clientMinVersion: HandshakeVersion1,
+			clientMaxVersion: HandshakeVersion1,
+		},
+		{
+			name:             "server v1 and client v1 small auth",
+			serverMinVersion: HandshakeVersion1,
+			serverMaxVersion: HandshakeVersion1,
+			clientMinVersion: HandshakeVersion1,
+			clientMaxVersion: HandshakeVersion1,
+			authData:         []byte{0, 1, 2, 3, 4},
+		},
+		{
+			name:             "server v1 and client v1 large auth",
+			serverMinVersion: HandshakeVersion1,
+			serverMaxVersion: HandshakeVersion1,
+			clientMinVersion: HandshakeVersion1,
+			clientMaxVersion: HandshakeVersion1,
+			authData:         largeAuthData,
+		},
+		{
+			name:             "server v0 and client [v0, v1]",
+			serverMinVersion: HandshakeVersion0,
+			serverMaxVersion: HandshakeVersion0,
+			clientMinVersion: HandshakeVersion0,
+			clientMaxVersion: HandshakeVersion1,
+			authData:         []byte{0, 1, 2, 3},
+		},
+		{
+			name:             "server v1 and client [v0, v1]",
+			serverMinVersion: HandshakeVersion0,
+			serverMaxVersion: HandshakeVersion1,
+			clientMinVersion: HandshakeVersion0,
+			clientMaxVersion: HandshakeVersion1,
+			authData:         largeAuthData,
 		},
 	}
 

--- a/mailbox/tcp_noise_conn.go
+++ b/mailbox/tcp_noise_conn.go
@@ -104,6 +104,15 @@ func Dial(localPriv keychain.SingleKeyECDH, netAddr net.Addr, passphrase []byte,
 		return nil, err
 	}
 
+	// Read the authData from the server if using a handshake version above
+	// version 0.
+	if b.noise.handshakeVersion > HandshakeVersion0 {
+		if err := b.noise.ReadAuthData(conn); err != nil {
+			b.conn.Close()
+			return nil, err
+		}
+	}
+
 	// We'll reset the deadline as it's no longer critical beyond the
 	// initial handshake.
 	err = conn.SetReadDeadline(time.Time{})

--- a/mailbox/tcp_noise_conn.go
+++ b/mailbox/tcp_noise_conn.go
@@ -44,7 +44,10 @@ func Dial(localPriv keychain.SingleKeyECDH, netAddr net.Addr, passphrase []byte,
 		return nil, err
 	}
 
-	noise, err := NewBrontideMachine(true, localPriv, passphrase)
+	noise, err := NewBrontideMachine(
+		true, localPriv, passphrase, MinHandshakeVersion,
+		MaxHandshakeVersion,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/mailbox/tcp_noise_listner.go
+++ b/mailbox/tcp_noise_listner.go
@@ -115,7 +115,8 @@ func (l *Listener) doHandshake(conn net.Conn) {
 	remoteAddr := conn.RemoteAddr().String()
 
 	noise, err := NewBrontideMachine(
-		false, l.localStatic, l.passphrase, AuthDataPayload(l.authData),
+		false, l.localStatic, l.passphrase, MinHandshakeVersion,
+		MaxHandshakeVersion, AuthDataPayload(l.authData),
 	)
 	if err != nil {
 		l.rejectConn(rejectedConnErr(err, remoteAddr))

--- a/mailbox/tcp_noise_listner.go
+++ b/mailbox/tcp_noise_listner.go
@@ -197,6 +197,17 @@ func (l *Listener) doHandshake(conn net.Conn) {
 		return
 	}
 
+	// Send the authData to the client in a normal message if we are using
+	// a handshake version above version 0.
+	if brontideConn.noise.handshakeVersion > HandshakeVersion0 {
+		err := brontideConn.noise.WriteAuthData(brontideConn.conn)
+		if err != nil {
+			brontideConn.conn.Close()
+			l.rejectConn(rejectedConnErr(err, remoteAddr))
+			return
+		}
+	}
+
 	// We'll reset the deadline as it's no longer critical beyond the
 	// initial handshake.
 	err = conn.SetReadDeadline(time.Time{})


### PR DESCRIPTION
Fixes #16 

In this PR, we allow the `authData` sent by the noise responder in Act 2 to be of variable length. In order to accomplish this, the Act 2 message had to be changed slightly so that the length of the auth data could be included before the `EncryptAndHash` step so that we know how many bytes to read for that step. 

In order to read Act 2 payload in a more stream-like way, the first commit adds a recv buffer to the `connKit` so that we can call `Read` multiple times without actually calling GBN to recv multiple times