### PR TITLE
gbn: ping and Nack fix

### DIFF
--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -294,6 +294,10 @@ func (g *GoBackNConn) Close() error {
 	g.cancel()
 
 	g.wg.Wait()
+
+	g.pingTicker.Stop()
+	g.resendTicker.Stop()
+
 	log.Debugf("GBN is closed, isServer=%v", g.isServer)
 
 	return nil

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -233,6 +233,7 @@ func (g *GoBackNConn) start() {
 		pingTime = g.pingTime
 	}
 	g.pingTicker = NewIntervalAwareForceTicker(pingTime)
+	g.pingTicker.Resume()
 
 	g.resendTicker = time.NewTicker(g.resendTimeout)
 

--- a/gbn/queue.go
+++ b/gbn/queue.go
@@ -172,6 +172,15 @@ func (q *queue) processNACK(seq uint8) (bool, bool) {
 
 	log.Tracef("Received NACK %d", seq)
 
+	// If the NACK is the same as sequenceTop, it probably means that queue
+	// was sent successfully, but we just missed the necessary ACKs. So we
+	// can empty the queue here by bumping the base and we dont need to
+	// trigger a resend.
+	if seq == q.sequenceTop {
+		q.sequenceBase = q.sequenceTop
+		return true, false
+	}
+
 	// Is the NACKed sequence even in our queue?
 	if !containsSequence(q.sequenceBase, q.sequenceTop, seq) {
 		return false, false


### PR DESCRIPTION
Turns out, the ping keepalive ticker was never started. This PR:
- starts the ping ticker
- cleans up the tickers on gbn close
- ensures that NACK is handled properly for the case where the peer received the entire queue successfully. 