### PR TITLE
[WIP] multi: second handshake

### DIFF
--- a/cmd/wasm-client/lnd_conn.go
+++ b/cmd/wasm-client/lnd_conn.go
@@ -31,12 +31,15 @@ func mailboxRPCConnection(mailboxServer,
 	ecdh := &keychain.PrivKeyECDH{PrivKey: privKey}
 
 	ctx := context.Background()
-	transportConn, err := mailbox.NewClient(ctx, sid)
+	transportConn, err := mailbox.NewClient(ctx, mailboxServer, sid)
 	if err != nil {
 		return nil, err
 	}
 
-	noiseConn := mailbox.NewNoiseGrpcConn(ecdh, nil, password[:])
+	noiseConn := mailbox.NewNoiseGrpcConn(
+		ecdh, nil, nil, password[:], func(remoteKey *btcec.PublicKey) {
+
+		})
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithContextDialer(transportConn.Dial),

--- a/gbn/gbn_client.go
+++ b/gbn/gbn_client.go
@@ -31,6 +31,10 @@ func NewClientConn(n uint8, sendFunc sendBytesFunc, receiveFunc recvBytesFunc,
 	}
 
 	if err := conn.clientHandshake(); err != nil {
+		if err := conn.Close(); err != nil {
+			log.Errorf("error closing gbn ClientConn: %v", err)
+		}
+
 		return nil, err
 	}
 	conn.start()

--- a/gbn/gbn_server.go
+++ b/gbn/gbn_server.go
@@ -22,6 +22,10 @@ func NewServerConn(ctx context.Context, sendFunc sendBytesFunc,
 	}
 
 	if err := conn.serverHandshake(); err != nil {
+		if err := conn.Close(); err != nil {
+			log.Errorf("error closing ServerConn: %v", err)
+		}
+
 		return nil, err
 	}
 	conn.start()

--- a/itest/client_harness.go
+++ b/itest/client_harness.go
@@ -43,7 +43,7 @@ func (c *clientHarness) setConn(words []string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
-	transportConn, err := mailbox.NewClient(ctx, sid)
+	transportConn, err := mailbox.NewClient(ctx, c.serverAddr, sid)
 	if err != nil {
 		return err
 	}

--- a/itest/client_harness.go
+++ b/itest/client_harness.go
@@ -47,7 +47,10 @@ func (c *clientHarness) start() error {
 	c.cancel = cancel
 
 	noiseConn := mailbox.NewNoiseGrpcConn(
-		c.localStaticKey, nil, c.password[:],
+		c.localStaticKey, c.remoteStaticKey, nil, c.password[:],
+		func(remoteKey *btcec.PublicKey) {
+			c.remoteStaticKey = remoteKey
+		},
 	)
 
 	sid, err := noiseConn.SID()

--- a/itest/connection_test.go
+++ b/itest/connection_test.go
@@ -63,7 +63,7 @@ func testClientReconnect(t *harnessTest) {
 	require.NoError(t.t, t.client.cleanup())
 
 	// Restart the client.
-	require.NoError(t.t, t.client.setConn(t.server.password[:]))
+	require.NoError(t.t, t.client.start())
 
 	resp, err = t.client.clientConn.MockServiceMethod(
 		ctx, &mockrpc.Request{Req: defaultMessage},
@@ -82,7 +82,7 @@ func testServerReconnect(t *harnessTest) {
 	require.Equal(t.t, len(defaultMessage)*10, len(resp.Resp))
 
 	t.server.stop()
-	require.NoError(t.t, t.server.start(false))
+	require.NoError(t.t, t.server.start())
 
 	select {
 	case err := <-t.server.errChan:

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -18,18 +18,32 @@ type serverHarness struct {
 	mockServer *grpc.Server
 	server     *mockrpc.Server
 	password   [mailbox.NumPasswordWords]string
+	localKey   keychain.SingleKeyECDH
+	remoteKey  *btcec.PublicKey
 
 	errChan chan error
 
 	wg sync.WaitGroup
 }
 
-func newServerHarness(serverHost string, insecure bool) *serverHarness {
+func newServerHarness(serverHost string, insecure bool) (*serverHarness, error) {
+	password, _, err := mailbox.NewPassword()
+	if err != nil {
+		return nil, err
+	}
+
+	privKey, err := btcec.NewPrivateKey(btcec.S256())
+	if err != nil {
+		return nil, err
+	}
+
 	return &serverHarness{
 		serverHost: serverHost,
 		insecure:   insecure,
+		password:   password,
+		localKey:   &keychain.PrivKeyECDH{PrivKey: privKey},
 		errChan:    make(chan error, 1),
-	}
+	}, nil
 }
 
 func (s *serverHarness) stop() {
@@ -37,20 +51,7 @@ func (s *serverHarness) stop() {
 	s.wg.Wait()
 }
 
-func (s *serverHarness) start(newPassword bool) error {
-	if newPassword {
-		password, _, err := mailbox.NewPassword()
-		if err != nil {
-			return err
-		}
-		s.password = password
-	}
-
-	privKey, err := btcec.NewPrivateKey(btcec.S256())
-	if err != nil {
-		return err
-	}
-
+func (s *serverHarness) start() error {
 	tlsConfig := &tls.Config{}
 	if s.insecure {
 		tlsConfig = &tls.Config{
@@ -58,9 +59,8 @@ func (s *serverHarness) start(newPassword bool) error {
 		}
 	}
 
-	ecdh := &keychain.PrivKeyECDH{PrivKey: privKey}
 	pswdEntropy := mailbox.PasswordMnemonicToEntropy(s.password)
-	noiseConn := mailbox.NewNoiseGrpcConn(ecdh, nil, pswdEntropy[:])
+	noiseConn := mailbox.NewNoiseGrpcConn(s.localKey, nil, pswdEntropy[:])
 
 	sid, err := noiseConn.SID()
 	if err != nil {

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -60,7 +60,12 @@ func (s *serverHarness) start() error {
 	}
 
 	pswdEntropy := mailbox.PasswordMnemonicToEntropy(s.password)
-	noiseConn := mailbox.NewNoiseGrpcConn(s.localKey, nil, pswdEntropy[:])
+	noiseConn := mailbox.NewNoiseGrpcConn(
+		s.localKey, s.remoteKey, nil, pswdEntropy[:],
+		func(remoteKey *btcec.PublicKey) {
+			s.remoteKey = remoteKey
+		},
+	)
 
 	sid, err := noiseConn.SID()
 	if err != nil {

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -158,8 +158,12 @@ func setupHarnesses(t *testing.T) (*clientHarness, *serverHarness,
 func setupClientAndServerHarnesses(t *testing.T,
 	mailboxAddr string, insecure bool) (*clientHarness, *serverHarness) {
 
-	serverHarness := newServerHarness(mailboxAddr, insecure)
-	if err := serverHarness.start(true); err != nil {
+	serverHarness, err := newServerHarness(mailboxAddr, insecure)
+	if err != nil {
+		t.Fatalf("could not create new server: %v", err)
+	}
+
+	if err := serverHarness.start(); err != nil {
 		t.Fatalf("could not start server: %v", err)
 	}
 
@@ -174,8 +178,14 @@ func setupClientAndServerHarnesses(t *testing.T,
 	// Give the server some time to set up the first mailbox
 	time.Sleep(1000 * time.Millisecond)
 
-	clientHarness := newClientHarness(mailboxAddr)
-	if err := clientHarness.setConn(serverHarness.password[:]); err != nil {
+	clientHarness, err := newClientHarness(
+		mailboxAddr, serverHarness.password,
+	)
+	if err != nil {
+		t.Fatalf("could not create new client harness: %v", err)
+	}
+
+	if err := clientHarness.start(); err != nil {
 		t.Fatalf("could not connect client: %v", err)
 	}
 

--- a/mailbox/client.go
+++ b/mailbox/client.go
@@ -27,9 +27,7 @@ func NewClient(ctx context.Context, sid [64]byte) (*Client, error) {
 // called everytime grpc retries the connection. If this is the first
 // connection, a new ClientConn will be created. Otherwise, the existing
 // connection will just be refreshed.
-func (c *Client) Dial(_ context.Context, serverHost string) (net.Conn,
-	error) {
-
+func (c *Client) Dial(_ context.Context, serverHost string) (net.Conn, error) {
 	// If there is currently an active connection, block here until the
 	// previous connection as been closed.
 	if c.mailboxConn != nil {
@@ -49,7 +47,7 @@ func (c *Client) Dial(_ context.Context, serverHost string) (net.Conn,
 		}
 		c.mailboxConn = mailboxConn
 	} else {
-		mailboxConn, err := RefreshClientConn(c.ctx, c.mailboxConn)
+		mailboxConn, err := RefreshClientConn(c.mailboxConn)
 		if err != nil {
 			if err := mailboxConn.Close(); err != nil {
 				return nil, &temporaryError{err}

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -139,7 +139,7 @@ func NewClientConn(ctx context.Context, sid [64]byte,
 		gbnN, c.sendToStream, c.recvFromStream, c.gbnOptions...,
 	)
 	if err != nil {
-		return c, err
+		return nil, err
 	}
 	c.gbnConn = gbnConn
 
@@ -149,9 +149,7 @@ func NewClientConn(ctx context.Context, sid [64]byte,
 // RefreshClientConn creates a new ClientConn object with the same values as
 // the passed ClientConn but with a new quit channel, a new closeOnce var and
 // a new gbn connection.
-func RefreshClientConn(ctx context.Context, c *ClientConn) (*ClientConn,
-	error) {
-
+func RefreshClientConn(c *ClientConn) (*ClientConn, error) {
 	c.sendStreamMu.Lock()
 	defer c.sendStreamMu.Unlock()
 
@@ -171,7 +169,7 @@ func RefreshClientConn(ctx context.Context, c *ClientConn) (*ClientConn,
 	c.receiveSocket = nil
 
 	cc.connKit = &connKit{
-		ctx:        ctx,
+		ctx:        c.ctx,
 		impl:       cc,
 		receiveSID: c.receiveSID,
 		sendSID:    c.sendSID,

--- a/mailbox/noise_patterns.go
+++ b/mailbox/noise_patterns.go
@@ -1,5 +1,10 @@
 package mailbox
 
+const (
+	XX = "XXeke+SPAKE2"
+	KK = "KK"
+)
+
 var (
 	// XXPattern represents the XX Noise pattern using SPAKE2 to mask
 	// the ephemeral key of the first message.
@@ -7,7 +12,7 @@ var (
 	// <- e, ee, s, es
 	// -> s, se
 	XXPattern = HandshakePattern{
-		Name: "XXeke+SPAKE2",
+		Name: XX,
 		Pattern: []MessagePattern{
 			{
 				Tokens:    []Token{me},
@@ -35,7 +40,7 @@ var (
 	// <- e, es, ss
 	// -> e, ee, se
 	KKPattern = HandshakePattern{
-		Name: "KK",
+		Name: KK,
 		PreMessages: []MessagePattern{
 			{
 				Tokens:    []Token{s},

--- a/mailbox/server.go
+++ b/mailbox/server.go
@@ -75,20 +75,13 @@ func (s *Server) Accept() (net.Conn, error) {
 		}
 	}
 
-	receiveSID := GetSID(s.sid, false)
-	sendSID := GetSID(s.sid, true)
-
 	// If this is the first connection, we create a new ServerConn object.
 	// otherwise, we just refresh the ServerConn.
 	if s.mailboxConn == nil {
 		mailboxConn, err := NewServerConn(
-			s.ctx, s.serverHost, s.client, receiveSID, sendSID,
+			s.ctx, s.serverHost, s.client, s.sid,
 		)
 		if err != nil {
-			log.Errorf("couldn't create new server: %v", err)
-			if err := mailboxConn.Close(); err != nil {
-				return nil, &temporaryError{err}
-			}
 			return nil, &temporaryError{err}
 		}
 		s.mailboxConn = mailboxConn

--- a/mailbox/server_conn.go
+++ b/mailbox/server_conn.go
@@ -42,10 +42,12 @@ type ServerConn struct {
 // NewServerConn creates a new net.Conn compatible server connection that uses
 // a gRPC based connection to tunnel traffic over a mailbox server.
 func NewServerConn(ctx context.Context, serverHost string,
-	client hashmailrpc.HashMailClient, receiveSID,
-	sendSID [64]byte) (*ServerConn, error) {
+	client hashmailrpc.HashMailClient, sid [64]byte) (*ServerConn, error) {
 
 	ctxc, cancel := context.WithCancel(ctx)
+
+	receiveSID := GetSID(sid, false)
+	sendSID := GetSID(sid, true)
 
 	c := &ServerConn{
 		client: client,
@@ -71,7 +73,7 @@ func NewServerConn(ctx context.Context, serverHost string,
 		ctxc, c.sendToStream, c.recvFromStream, c.gbnOptions...,
 	)
 	if err != nil {
-		return c, err
+		return nil, err
 	}
 	log.Debugf("ServerConn: done creating gbn")
 

--- a/mailbox/switch.go
+++ b/mailbox/switch.go
@@ -1,0 +1,115 @@
+package mailbox
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+// SwitchConn is an abstraction over an underlying ProxyConn. It allows us to
+// keep the same SwitchConn and use it as a ProxyConn while also allowing us to
+// switch out the ProxyConn with a new one if needed.
+type SwitchConn struct {
+	*SwitchConfig
+
+	ProxyConn
+
+	closeOnce sync.Once
+	quit      chan struct{}
+}
+
+// SwitchConfig holds all the config values and functions used by SwitchConn.
+type SwitchConfig struct {
+	ServerHost string
+	SID        [64]byte
+
+	// NewProxyConn should return a new ProxyConn given the sid provided.
+	NewProxyConn func(sid [64]byte) (ProxyConn, error)
+
+	// RefreshProxyConn should return a ProxyConn that effectively
+	// refreshes the one passed in.
+	RefreshProxyConn func(conn ProxyConn) (ProxyConn, error)
+
+	// StopProxyCon should stop and clean up the given ProxyConn.
+	StopProxyConn func(conn ProxyConn) error
+}
+
+// NextSwitchConn returns a new SwitchConn or refreshed SwitchConn depending on
+// if a nil SwitchConn is passed in or not.
+func NextSwitchConn(sc *SwitchConn, cfg *SwitchConfig) (*SwitchConn, error) {
+	if sc == nil {
+		return newSwitchConn(cfg)
+	}
+
+	return refreshSwitchConn(sc)
+}
+
+// newSwitchConn creates a new SwitchConn object with a new underlying
+// ProxyConn.
+func newSwitchConn(cfg *SwitchConfig) (*SwitchConn, error) {
+	mailboxConn, err := cfg.NewProxyConn(cfg.SID)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create new server: %v", err)
+	}
+
+	return &SwitchConn{
+		SwitchConfig: cfg,
+		ProxyConn:    mailboxConn,
+		quit:         make(chan struct{}),
+	}, nil
+}
+
+// refreshSwitchConn refreshes both the SwitchConn by creating a new one with
+// a new quit channel and also refreshes the underlying ProxyConn.
+func refreshSwitchConn(s *SwitchConn) (*SwitchConn, error) {
+	sc := &SwitchConn{
+		SwitchConfig: s.SwitchConfig,
+		quit:         make(chan struct{}),
+	}
+
+	conn, err := s.RefreshProxyConn(s.ProxyConn)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.ProxyConn = conn
+
+	return sc, nil
+}
+
+// Addr returns the current address of the SwitchConn.
+func (s *SwitchConn) Addr() net.Addr {
+	return &Addr{SID: s.SID, Server: s.ServerHost}
+}
+
+// Close cleans up the SwitchConn and its ProxyConn.
+func (s *SwitchConn) Close() error {
+	var returnErr error
+	s.closeOnce.Do(func() {
+		if err := s.ProxyConn.Close(); err != nil {
+			returnErr = err
+		}
+
+		close(s.quit)
+	})
+
+	return returnErr
+}
+
+// Done returns the SwitchConn's quit channel which can be used to determine
+// if the Switch conn has completed closing or not.
+func (s *SwitchConn) Done() chan struct{} {
+	return s.quit
+}
+
+// Switch stops the current ProxyConn and switches it out with a new ProxyConn.
+func (s *SwitchConn) Switch(conn ProxyConn, sid [64]byte) error {
+	if err := s.StopProxyConn(s.ProxyConn); err != nil {
+		return err
+	}
+
+	s.SID = sid
+	s.ProxyConn = conn
+
+	return nil
+}


### PR DESCRIPTION
This works but is still a WIP cause it can probably be made cleaner. I think this will be a bit tricky to review as is. 

Other than trying to get it to be nicer looking, I need to still do the following in this PR:

1. Need to updated `tcp_noise_conn.go` and `tcp_noise_listener.go` to use the new handshake flow. (waiting on this cause i am hoping that simplifying the current code will then make it easier to add the flow to these)
2. Need to add "persist remote static key to local storage" func to the wasm client.