### PR TITLE
cmd/wasm-client: make client connection blocking

### DIFF
--- a/cmd/wasm-client/lnd_conn.go
+++ b/cmd/wasm-client/lnd_conn.go
@@ -44,6 +44,7 @@ func mailboxRPCConnection(mailboxServer, pairingPhrase string,
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(1024 * 1024 * 200),
 		),
+		grpc.WithBlock(),
 	}
 
 	return transportConn.ConnStatus, func() (*grpc.ClientConn, error) {

--- a/itest/client_harness.go
+++ b/itest/client_harness.go
@@ -66,6 +66,7 @@ func (c *clientHarness) start() error {
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(1024 * 1024 * 200),
 		),
+		grpc.WithBlock(),
 	}
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{


### PR DESCRIPTION
In this commit, we add a WithBlock client dial option so that the
connection is not returned until the connection has been established
(ie, handshake is complete)