### PR TITLE
multi: expose connection status

### DIFF
--- a/cmd/wasm-client/go.mod
+++ b/cmd/wasm-client/go.mod
@@ -12,4 +12,8 @@ require (
 	google.golang.org/grpc v1.39.0
 )
 
+replace github.com/lightninglabs/lightning-node-connect => ../../
+
+replace github.com/lightninglabs/lightning-node-connect/hashmailrpc => ../../hashmailrpc
+
 go 1.16

--- a/cmd/wasm-client/go.sum
+++ b/cmd/wasm-client/go.sum
@@ -505,10 +505,6 @@ github.com/lightninglabs/faraday v0.2.7-alpha.0.20220503144421-cd1e56982f09 h1:4
 github.com/lightninglabs/faraday v0.2.7-alpha.0.20220503144421-cd1e56982f09/go.mod h1:YyeMuBbsqJ85wT6j1rCmTPMuk5a5Iz+QouiTN6qQiQ0=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
-github.com/lightninglabs/lightning-node-connect v0.1.9-alpha.0.20220602120524-e9964c685b18 h1:V68nv3ZyoWu/pEDlhaS81Tq6/LMPLsop2sV+WlxD4F4=
-github.com/lightninglabs/lightning-node-connect v0.1.9-alpha.0.20220602120524-e9964c685b18/go.mod h1:dgyhE+O4GpWBhS7yIzKCm8LqFHX8/QRwJ6OWFrN+WnA=
-github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
-github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
 github.com/lightninglabs/lndclient v0.15.0-0/go.mod h1:ORS/YFe9hAXlzN/Uj+gvTmrnXEml6yD6dWwzCjpTJyQ=
 github.com/lightninglabs/lndclient v0.15.0-2/go.mod h1:bef6exkGOboLNGZpx+nJFspmyV/CSiO/aIeWj9UFqE4=
 github.com/lightninglabs/loop v0.18.0-beta h1:Xnx2u96MX/4uIeKei4MmkCEXbSgooS3u9pC/ZqoCNf0=

--- a/example/index.html
+++ b/example/index.html
@@ -72,6 +72,13 @@ Add the following polyfill for Microsoft Edge 17/18 support:
             }
         }
         readyTicker = setInterval(isReady, 200);
+
+        let connStatus = function () {
+            let result = window[namespace].wasmClientStatus();
+            document.getElementById('status').innerHTML = "Connection Status: " + result;
+        }
+        setInterval(connStatus, 200);
+
         await go.run(instance);
         await WebAssembly.instantiate(module, go.importObject);
     }
@@ -174,7 +181,11 @@ Add the following polyfill for Microsoft Edge 17/18 support:
     </button>
 </div>
 
-<br /><br />
+<br />
+
+<h4 id="status"></h4>
+
+<br />
 
 <div id="ready" style="display:none">
     <pre id="output">

--- a/example/index.html
+++ b/example/index.html
@@ -40,6 +40,11 @@ Add the following polyfill for Microsoft Edge 17/18 support:
             remoteKey = localStorage.getItem(namespace+":remoteKey")
         }
 
+        if (localStorage.getItem(namespace+":mailboxHost")) {
+            server = localStorage.getItem(namespace+":mailboxHost")
+            document.getElementById('server').value = server
+        }
+
         console.clear();
         go.argv = [
             'wasm-client',
@@ -93,12 +98,7 @@ Add the following polyfill for Microsoft Edge 17/18 support:
 
     async function connectServer() {
         let server = $('#server').val();
-
-        if (localStorage.getItem(namespace+":mailboxHost")) {
-            server = localStorage.getItem(namespace+":mailboxHost")
-        } else {
-            localStorage.setItem(namespace+":mailboxHost", server)
-        }
+        localStorage.setItem(namespace+":mailboxHost", server)
 
         let passphrase = $('#phrase').val();
         let connectedTicker = null;


### PR DESCRIPTION
In this PR, we expose the connection status of the Client so that callers can check if the status is in one of the following categories:

- **ConnStatusNotConnected:** the client is not connected at all this is likely due to the mailbox server being down.
- **ConnStatusSessionNotFound:** the connection to the mailbox server was successful but that the mailbox with the given ID was not found. This either means that the server is down, that the session has expired or that the user entered passphrase was incorrect.
- **ConnStatusSessionInUse:** the connection to the mailbox server was successful but that the stream for the session is already occupied by another client.
- **ConnStatusConnected:** ConnStatusConnected indicates that the connection to both the mailbox server and end server was successful.

This addresses [this](https://github.com/lightninglabs/lightning-node-connect/issues/31#issuecomment-1126790384) comment. 

The wasm client example page has also been updated to demonstrate this new feature :)
