### PR TITLE
wasm: pass keys in as parameters to ConnectServer

### DIFF
--- a/cmd/wasm-client/config.go
+++ b/cmd/wasm-client/config.go
@@ -3,43 +3,12 @@
 
 package main
 
-import (
-	"errors"
-	"fmt"
-)
-
 type config struct {
 	DebugLevel string `long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	NameSpace  string `long:"namespace" description:"The name of the JS namespace in which all the call back functions should be registered"`
-
-	LocalPrivate string `long:"localprivate" description:"The static local private key to be used for creating the noise connection"`
-	RemotePublic string `long:"remotepublic" description:"The static remote public key to be used for creating the noise connection"`
 
 	OnLocalPrivCreate  string `long:"onlocalprivcreate" description:"The name of the js callback function that should be called once the local private key has been generated. This function is expected to persist the key so that it can be provided via a command line flag on a future connection"`
 	OnRemoteKeyReceive string `long:"onremotekeyreceive" description:"The name of the js callback function to be called once the client receives the remote static key. This function is expected to persist the key so that it can be provided via a command line flag on a future connection"`
 
 	OnAuthData string `long:"onauthdata" description:"The name of the js callback function to be called once the client receives auth data from the remote peer."`
-}
-
-func (c *config) validate() error {
-	if c.NameSpace == "" {
-		return fmt.Errorf("a non-empty namespace is required")
-	}
-
-	if c.RemotePublic != "" && c.LocalPrivate == "" {
-		return errors.New("cannot set remote pub key if local priv " +
-			"key is not also set")
-	}
-
-	if c.LocalPrivate == "" && c.OnLocalPrivCreate == "" {
-		return errors.New("OnLocalPrivCreate must be defined if a " +
-			"local key is not provided")
-	}
-
-	if c.RemotePublic == "" && c.OnRemoteKeyReceive == "" {
-		return errors.New("OnRemoteKeyReceive must be defined if a " +
-			"remote key is not provided")
-	}
-
-	return nil
 }

--- a/example/index.html
+++ b/example/index.html
@@ -29,17 +29,6 @@ Add the following polyfill for Microsoft Edge 17/18 support:
     async function startInstance(module, instance) {
         namespace = $('#namespace').val();
 
-        let localKey = ""
-        let remoteKey = ""
-
-        if (localStorage.getItem(namespace+":localKey")) {
-            localKey = localStorage.getItem(namespace+":localKey")
-        }
-
-        if (localStorage.getItem(namespace+":remoteKey")) {
-            remoteKey = localStorage.getItem(namespace+":remoteKey")
-        }
-
         if (localStorage.getItem(namespace+":mailboxHost")) {
             server = localStorage.getItem(namespace+":mailboxHost")
             document.getElementById('server').value = server
@@ -50,8 +39,6 @@ Add the following polyfill for Microsoft Edge 17/18 support:
             'wasm-client',
             '--debuglevel=trace',
             '--namespace='+namespace,
-            '--localprivate='+localKey,
-            '--remotepublic='+remoteKey,
             '--onlocalprivcreate=onLocalKeyCreate',
             '--onremotekeyreceive=onRemoteKeyReceive',
             '--onauthdata=onAuthData',
@@ -70,7 +57,7 @@ Add the following polyfill for Microsoft Edge 17/18 support:
 
             // If we have a remote key stored, it means that the handshake we will do to create a connection will not
             // involve the passphrase, so we can immediately connect to the server.
-            if (remoteKey != "") {
+            if (localStorage.getItem(namespace+":remoteKey")) {
                 connectServer()
             } else {
                 $('#passphrase').show();
@@ -100,6 +87,17 @@ Add the following polyfill for Microsoft Edge 17/18 support:
         let server = $('#server').val();
         localStorage.setItem(namespace+":mailboxHost", server)
 
+        let localKey = ""
+        let remoteKey = ""
+
+        if (localStorage.getItem(namespace+":localKey")) {
+            localKey = localStorage.getItem(namespace+":localKey")
+        }
+
+        if (localStorage.getItem(namespace+":remoteKey")) {
+            remoteKey = localStorage.getItem(namespace+":remoteKey")
+        }
+
         let passphrase = $('#phrase').val();
         let connectedTicker = null;
         let isConnected = function () {
@@ -113,7 +111,7 @@ Add the following polyfill for Microsoft Edge 17/18 support:
             }
         }
         connectedTicker = setInterval(isConnected, 200);
-        window[namespace].wasmClientConnectServer(server, true, passphrase);
+        window[namespace].wasmClientConnectServer(server, true, passphrase, localKey, remoteKey);
     }
 
     async function clearStorage() {


### PR DESCRIPTION
In this commit, the way in which the local and remote keys are specified
is changed. Instead of passing them in as command line arguments to the
binary, they are instead passed in as parameters to the ConnectServer
function.

This change allows the wasm binary to be pre-loaded and then only 
providing the keys afterwards. Rather than needing to provide the keys at 
load time.