### PR TITLE
gbn+mailbox: pass context to gbn.NewClientConn

### DIFF
--- a/gbn/gbn_client.go
+++ b/gbn/gbn_client.go
@@ -13,17 +13,15 @@ import (
 // The receiveStream function must read from an underlying transport stream.
 // The resendTimeout parameter defines the duration to wait before resending data
 // if the corresponding ACK for the data is not received.
-func NewClientConn(n uint8, sendFunc sendBytesFunc, receiveFunc recvBytesFunc,
-	opts ...Option) (*GoBackNConn, error) {
+func NewClientConn(ctx context.Context, n uint8, sendFunc sendBytesFunc,
+	receiveFunc recvBytesFunc, opts ...Option) (*GoBackNConn, error) {
 
 	if n == math.MaxUint8 {
 		return nil, fmt.Errorf("n must be smaller than %d",
 			math.MaxUint8)
 	}
 
-	conn := newGoBackNConn(
-		context.Background(), sendFunc, receiveFunc, false, n,
-	)
+	conn := newGoBackNConn(ctx, sendFunc, receiveFunc, false, n)
 
 	// Apply functional options
 	for _, o := range opts {

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -350,8 +350,12 @@ func (g *GoBackNConn) Close() error {
 
 		g.wg.Wait()
 
-		g.pingTicker.Stop()
-		g.resendTicker.Stop()
+		if g.pingTicker != nil {
+			g.pingTicker.Stop()
+		}
+		if g.resendTicker != nil {
+			g.resendTicker.Stop()
+		}
 
 		log.Debugf("GBN is closed, isServer=%v", g.isServer)
 	})

--- a/gbn/gbn_conn_test.go
+++ b/gbn/gbn_conn_test.go
@@ -174,7 +174,7 @@ func TestServerHandshakeTimeout(t *testing.T) {
 	// Give the server time to be ready for the handshake
 	time.Sleep(time.Millisecond * 200)
 
-	client, err := NewClientConn(10, s2Write, s1Read)
+	client, err := NewClientConn(ctx, 10, s2Write, s1Read)
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -1205,7 +1205,7 @@ func setUpClientServerConns(t *testing.T, n uint8,
 	// Give the server time to be ready for the handshake
 	time.Sleep(time.Millisecond * 200)
 
-	client, err := NewClientConn(n, cWrite, cRead, opts...)
+	client, err := NewClientConn(ctx, n, cWrite, cRead, opts...)
 	require.NoError(t, err)
 
 	wg.Wait()

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -173,7 +173,7 @@ func NewClientConn(ctx context.Context, sid [64]byte, serverHost string,
 	}
 
 	gbnConn, err := gbn.NewClientConn(
-		gbnN, c.sendToStream, c.recvFromStream, c.gbnOptions...,
+		ctx, gbnN, c.sendToStream, c.recvFromStream, c.gbnOptions...,
 	)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func RefreshClientConn(ctx context.Context, c *ClientConn) (*ClientConn,
 	}
 
 	gbnConn, err := gbn.NewClientConn(
-		gbnN, cc.sendToStream, cc.recvFromStream, cc.gbnOptions...,
+		ctx, gbnN, cc.sendToStream, cc.recvFromStream, cc.gbnOptions...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Pass an existing context to gbn.NewClientConn so that a caller can
cancel the gbn handshake process.