### PR TITLE
multi: change websocket close status

### DIFF
--- a/cmd/wasm-client/main.go
+++ b/cmd/wasm-client/main.go
@@ -250,6 +250,9 @@ func (w *wasmClient) ConnectServer(_ js.Value, args []js.Value) interface{} {
 
 		w.statusChecker = statusChecker
 		w.lndConn, err = lndConnect()
+		if err != nil {
+			exit(err)
+		}
 
 		log.Debugf("WASM client connected to RPC")
 	}()
@@ -266,6 +269,7 @@ func (w *wasmClient) Disconnect(_ js.Value, _ []js.Value) interface{} {
 		if err := w.lndConn.Close(); err != nil {
 			log.Errorf("Error closing RPC connection: %v", err)
 		}
+		w.lndConn = nil
 	}
 
 	return nil

--- a/example/index.html
+++ b/example/index.html
@@ -90,6 +90,14 @@ Add the following polyfill for Microsoft Edge 17/18 support:
         });
     }
 
+    async function disconnect() {
+        window[namespace].wasmClientDisconnect();
+
+        document.getElementById('disconnectBtn').disabled = true;
+        document.getElementById('reconnectBtn').disabled = false;
+        document.getElementById('ready').style.display= 'none' ;
+    }
+
     async function connectServer() {
         let server = $('#server').val();
         localStorage.setItem(namespace+":mailboxHost", server)
@@ -119,6 +127,9 @@ Add the following polyfill for Microsoft Edge 17/18 support:
         }
         connectedTicker = setInterval(isConnected, 200);
         window[namespace].wasmClientConnectServer(server, true, passphrase, localKey, remoteKey);
+
+        document.getElementById('disconnectBtn').disabled = false;
+        document.getElementById('reconnectBtn').disabled = true;
     }
 
     async function clearStorage() {
@@ -242,6 +253,9 @@ Add the following polyfill for Microsoft Edge 17/18 support:
 <h4 id="expiry"></h4>
 
 <h4 id="sessiontype"></h4>
+
+<button onClick="disconnect();" id="disconnectBtn" disabled>Disconnect</button>
+<button onClick="connectServer();" id="reconnectBtn" disabled>Reconnect</button>
 
 <br />
 

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -537,8 +537,12 @@ func (c *ClientConn) Close() error {
 		if c.receiveSocket != nil {
 			log.Debugf("sending bye on receive socket")
 			returnErr = c.receiveSocket.Close(
-				websocket.StatusGoingAway, "bye",
+				websocket.StatusNormalClosure, "bye",
 			)
+			if returnErr != nil {
+				log.Errorf("Error closing receive socket: %v",
+					returnErr)
+			}
 		}
 		c.receiveStreamMu.Unlock()
 
@@ -546,8 +550,12 @@ func (c *ClientConn) Close() error {
 		if c.sendSocket != nil {
 			log.Debugf("sending bye on send socket")
 			returnErr = c.sendSocket.Close(
-				websocket.StatusGoingAway, "bye",
+				websocket.StatusNormalClosure, "bye",
 			)
+			if returnErr != nil {
+				log.Errorf("Error closing send socket: %v",
+					returnErr)
+			}
 		}
 		c.sendStreamMu.Unlock()
 


### PR DESCRIPTION
fixes #46 

When compiled in wasm, errors are thrown when attempting to close a websocket connection with `StatusGoingAway`. Things work properly if `StatusNormalClosure` is used instead. 

The example client is updated with `Disconnect` and `Reconnect` buttons to demonstrate that disconnect/reconnect now works.