### PR TITLE
example: enable buttons even when expiry is null

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -168,11 +168,10 @@ Add the following polyfill for Microsoft Edge 17/18 support:
         let expiry = window[namespace].wasmClientGetExpiry();
         if (!expiry) {
             document.getElementById('expiry').innerHTML = "No expiry found in macaroon";
-            return {}
+        } else {
+            localStorage.setItem(namespace+":expiry", expiry)
+            document.getElementById('expiry').innerHTML = "Session Expiry: "+new Date(expiry*1000).toLocaleString();
         }
-
-        localStorage.setItem(namespace+":expiry", expiry)
-        document.getElementById('expiry').innerHTML = "Session Expiry: "+new Date(expiry*1000).toLocaleString();
 
         // Determine if the session is a read only session.
         let readOnly = window[namespace].wasmClientIsReadOnly();


### PR DESCRIPTION
In TW, we set the expiry of a session to a date in the far far future. We use the value `253370782800` which is is Jan 1, 9999.  When connecting to this session in the example web app, the `wasmClientGetExpiry` function always returns `null`. This causes the `onAuthData` function in the page to return early, never enabling any of the buttons. This PR replaces the early return with an `else` to properly handle this edge case and allow the buttons to be enabled no matter what the expiry value is.