### PR TITLE
multi: send authData in itests

### DIFF
--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+var authData = []byte{1, 2, 3, 4}
+
 type serverHarness struct {
 	serverHost string
 	mockServer *grpc.Server
@@ -64,7 +66,7 @@ func (s *serverHarness) stop() {
 
 func (s *serverHarness) start() error {
 	connData := mailbox.NewConnData(
-		s.localStatic, s.remoteStatic, s.passphraseEntropy, nil,
+		s.localStatic, s.remoteStatic, s.passphraseEntropy, authData,
 		func(key *btcec.PublicKey) error {
 			s.remoteStatic = key
 			return nil

--- a/mailbox/conndata.go
+++ b/mailbox/conndata.go
@@ -58,7 +58,7 @@ type ConnData struct {
 func NewConnData(localKey keychain.SingleKeyECDH, remoteKey *btcec.PublicKey,
 	passphraseEntropy []byte, authData []byte,
 	onRemoteStatic func(key *btcec.PublicKey) error,
-	onAuthData func(date []byte) error) *ConnData {
+	onAuthData func(data []byte) error) *ConnData {
 
 	return &ConnData{
 		localKey:          localKey,


### PR DESCRIPTION
In this commit, we adjust the itests to send authData from the server to
the client and fail the test if the client does not receive the correct
authData from the server.