### PR TITLE
multi: server connection status

### DIFF
--- a/cmd/wasm-client/lnd_conn.go
+++ b/cmd/wasm-client/lnd_conn.go
@@ -16,7 +16,7 @@ import (
 func mailboxRPCConnection(mailboxServer, pairingPhrase string,
 	localStatic keychain.SingleKeyECDH, remoteStatic *btcec.PublicKey,
 	onRemoteStatic func(key *btcec.PublicKey) error,
-	onAuthData func(data []byte) error) (func() mailbox.ConnStatus,
+	onAuthData func(data []byte) error) (func() mailbox.ClientStatus,
 	func() (*grpc.ClientConn, error), error) {
 
 	words := strings.Split(pairingPhrase, " ")

--- a/cmd/wasm-client/main.go
+++ b/cmd/wasm-client/main.go
@@ -140,7 +140,7 @@ type wasmClient struct {
 
 	lndConn *grpc.ClientConn
 
-	statusChecker func() mailbox.ConnStatus
+	statusChecker func() mailbox.ClientStatus
 
 	mac *macaroon.Macaroon
 

--- a/itest/client_harness.go
+++ b/itest/client_harness.go
@@ -19,6 +19,7 @@ type clientHarness struct {
 
 	grpcConn   *grpc.ClientConn
 	clientConn mockrpc.MockServiceClient
+	client     *mailbox.Client
 
 	passphraseEntropy []byte
 	localStatic       keychain.SingleKeyECDH
@@ -65,6 +66,7 @@ func (c *clientHarness) start() error {
 	if err != nil {
 		return err
 	}
+	c.client = transportConn
 
 	noiseConn := mailbox.NewNoiseGrpcConn(connData)
 

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -25,6 +25,9 @@ type serverHarness struct {
 
 	tlsConfig *tls.Config
 
+	status   mailbox.ServerStatus
+	statusMu sync.Mutex
+
 	errChan chan error
 	wg      sync.WaitGroup
 }
@@ -74,7 +77,11 @@ func (s *serverHarness) start() error {
 	)
 
 	mailboxServer, err := mailbox.NewServer(
-		s.serverHost, connData, nil, grpc.WithTransportCredentials(
+		s.serverHost, connData, func(status mailbox.ServerStatus) {
+			s.statusMu.Lock()
+			s.status = status
+			s.statusMu.Unlock()
+		}, grpc.WithTransportCredentials(
 			credentials.NewTLS(s.tlsConfig),
 		),
 	)

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -74,7 +74,7 @@ func (s *serverHarness) start() error {
 	)
 
 	mailboxServer, err := mailbox.NewServer(
-		s.serverHost, connData, grpc.WithTransportCredentials(
+		s.serverHost, connData, nil, grpc.WithTransportCredentials(
 			credentials.NewTLS(s.tlsConfig),
 		),
 	)

--- a/mailbox/client.go
+++ b/mailbox/client.go
@@ -14,7 +14,7 @@ type Client struct {
 
 	connData *ConnData
 
-	status   ConnStatus
+	status   ClientStatus
 	statusMu sync.Mutex
 
 	sid [64]byte
@@ -33,7 +33,7 @@ func NewClient(ctx context.Context, connData *ConnData) (*Client, error) {
 	return &Client{
 		ctx:      ctx,
 		connData: connData,
-		status:   ConnStatusNotConnected,
+		status:   ClientStatusNotConnected,
 		sid:      sid,
 	}, nil
 }
@@ -73,7 +73,7 @@ func (c *Client) Dial(_ context.Context, serverHost string) (net.Conn, error) {
 
 	if c.mailboxConn == nil {
 		mailboxConn, err := NewClientConn(
-			c.ctx, c.sid, serverHost, func(status ConnStatus) {
+			c.ctx, c.sid, serverHost, func(status ClientStatus) {
 				c.statusMu.Lock()
 				c.status = status
 				c.statusMu.Unlock()
@@ -95,7 +95,7 @@ func (c *Client) Dial(_ context.Context, serverHost string) (net.Conn, error) {
 }
 
 // ConnStatus returns last determined client connection status.
-func (c *Client) ConnStatus() ConnStatus {
+func (c *Client) ConnStatus() ClientStatus {
 	c.statusMu.Lock()
 	defer c.statusMu.Unlock()
 


### PR DESCRIPTION
Add server connection status info so that a caller of the Server can get informed about changes in the Server's connection. The 3 statuses differ from the Client connection statuses. They are as follows:
- `ServerConnStatusNotConnected`: the server is not connected to the mailbox. This means it is either the mailbox is down or that the server is busy re-connecting to it.
- `ServerConnStatusInUse`: A client is currently connected to the server
- `ServerConnStatusIdle`: the server is connected to the mailbox and ready to accept a connection but there is no client currently connected.