### PR TITLE
multi: grpc client conn

### DIFF
--- a/cmd/wasm-client/lnd_conn.go
+++ b/cmd/wasm-client/lnd_conn.go
@@ -30,7 +30,9 @@ func mailboxRPCConnection(mailboxServer, pairingPhrase string,
 	)
 
 	ctx := context.Background()
-	transportConn, err := mailbox.NewClient(ctx, connData)
+	transportConn, err := mailbox.NewClient(
+		ctx, mailboxServer, connData, true,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/itest/client_harness.go
+++ b/itest/client_harness.go
@@ -62,7 +62,9 @@ func (c *clientHarness) start() error {
 		},
 	)
 
-	transportConn, err := mailbox.NewClient(ctx, connData)
+	transportConn, err := mailbox.NewClient(
+		ctx, c.serverAddr, connData, true,
+	)
 	if err != nil {
 		return err
 	}

--- a/itest/connection_test.go
+++ b/itest/connection_test.go
@@ -46,7 +46,6 @@ func testHashmailServerReconnect(t *harnessTest) {
 
 	// Shut down hashmail server
 	require.NoError(t.t, t.hmserver.stop())
-	t.t.Logf("")
 
 	// Check that the client and server status are updated appropriately.
 	assertServerStatus(t, mailbox.ServerStatusNotConnected)

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -1,10 +1,9 @@
 package itest
 
 import (
+	"fmt"
 	"testing"
 )
-
-const testnetMailbox = "mailbox.testnet.lightningcluster.com:443"
 
 // TestLightningNodeConnect runs the itests against a local mailbox instance.
 func TestLightningNodeConnect(t *testing.T) {
@@ -13,84 +12,50 @@ func TestLightningNodeConnect(t *testing.T) {
 		t.Skip("integration tests not selected")
 	}
 
-	ht := newHarnessTest(t, nil, nil, nil)
-	ht.setupLogging()
+	setupLogging(t)
+
+	testConfigs := []*testConfig{
+		{stagingMailbox: false, grpcClientConn: false},
+		{stagingMailbox: false, grpcClientConn: true},
+		{stagingMailbox: true, grpcClientConn: false},
+		{stagingMailbox: true, grpcClientConn: true},
+	}
 
 	t.Logf("Running %v integration tests", len(testCases))
 	for _, testCase := range testCases {
 
 		testCase := testCase
+		for _, config := range testConfigs {
+			config := config
 
-		success := t.Run(testCase.name, func(t1 *testing.T) {
-			clientHarness, serverHarness, hashmailHarness := setupHarnesses(t1)
-
-			ht := newHarnessTest(
-				t1, clientHarness, serverHarness,
-				hashmailHarness,
-			)
-
-			// Now we have everything to run the test case.
-			ht.RunTestCase(testCase)
-
-			// Shut down both client, server and hashmail server
-			// to remove all state.
-			err := ht.shutdown()
-			if err != nil {
-				t1.Fatalf("error shutting down harness: %v",
-					err)
+			if config.stagingMailbox && testCase.localMailboxOnly {
+				continue
 			}
-		})
 
-		// Close at the first failure. Mimic behavior of original test
-		// framework.
-		if !success {
-			break
-		}
-	}
-}
+			name := fmt.Sprintf("%s(stagingMailbox:%t,"+
+				"grpcClientConn:%t)", testCase.name,
+				config.stagingMailbox, config.grpcClientConn)
 
-// TestLightningNodeConnectTestnetMailbox runs the itests using the mailbox
-// running in the LL testnet environment.
-func TestLightningNodeConnectTestnetMailbox(t *testing.T) {
-	// If no tests are registered, then we can exit early.
-	if len(stagingMailboxTests) == 0 {
-		t.Skip("integration tests not selected")
-	}
+			success := t.Run(name, func(t1 *testing.T) {
+				ht := newHarnessTest(t1, config)
 
-	ht := newHarnessTest(t, nil, nil, nil)
-	ht.setupLogging()
+				// Now we have everything to run the test case.
+				ht.RunTestCase(testCase)
 
-	t.Logf("Running %v integration tests", len(stagingMailboxTests))
-	for _, testCase := range stagingMailboxTests {
+				// Shut down both client, server and hashmail
+				// server to remove all state.
+				err := ht.shutdown()
+				if err != nil {
+					t1.Fatalf("error shutting down "+
+						"harness: %v", err)
+				}
+			})
 
-		testCase := testCase
-
-		success := t.Run(testCase.name, func(t1 *testing.T) {
-			clientHarness, serverHarness :=
-				setupClientAndServerHarnesses(
-					t1, testnetMailbox, false,
-				)
-
-			ht := newHarnessTest(
-				t1, clientHarness, serverHarness, nil,
-			)
-
-			// Now we have everything to run the test case.
-			ht.RunTestCase(testCase)
-
-			// Shut down both client, server and hashmail server
-			// to remove all state.
-			err := ht.shutdown()
-			if err != nil {
-				t1.Fatalf("error shutting down harness: %v",
-					err)
+			// Close at the first failure. Mimic behavior of
+			// original test framework.
+			if !success {
+				break
 			}
-		})
-
-		// Close at the first failure. Mimic behavior of original test
-		// framework.
-		if !success {
-			break
 		}
 	}
 }

--- a/itest/test_list_off_test.go
+++ b/itest/test_list_off_test.go
@@ -4,5 +4,3 @@
 package itest
 
 var testCases []*testCase
-
-var stagingMailboxTests []*testCase

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -9,8 +9,9 @@ var testCases = []*testCase{
 		test: testHappyPath,
 	},
 	{
-		name: "test hashmail server reconnect",
-		test: testHashmailServerReconnect,
+		name:             "test hashmail server reconnect",
+		test:             testHashmailServerReconnect,
+		localMailboxOnly: true,
 	},
 	{
 		name: "test large response",
@@ -19,25 +20,6 @@ var testCases = []*testCase{
 	{
 		name: "test client reconnect",
 		test: testClientReconnect,
-	},
-	{
-		name: "test server reconnect",
-		test: testServerReconnect,
-	},
-}
-
-var stagingMailboxTests = []*testCase{
-	{
-		name: "test happy path",
-		test: testHappyPath,
-	},
-	{
-		name: "test client reconnect",
-		test: testClientReconnect,
-	},
-	{
-		name: "test large response",
-		test: testLargeResponse,
 	},
 	{
 		name: "test server reconnect",

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/lightning-node-connect/gbn"
-	"github.com/lightninglabs/lightning-node-connect/hashmailrpc"
 	"google.golang.org/protobuf/encoding/protojson"
-	"nhooyr.io/websocket"
 )
 
 var (
@@ -74,16 +72,6 @@ const (
 	// gbnPongTimout is the time after sending the pong message that we will
 	// timeout if we do not receive any message from our peer.
 	gbnPongTimeout = 3 * time.Second
-
-	// webSocketRecvLimit is used to set the websocket receive limit. The
-	// default value of 32KB is enough due to the fact that grpc has a
-	// default packet maximum of 32KB which we then further wrap in gbn and
-	// hashmail messages.
-	webSocketRecvLimit int64 = 100 * 1024 // 100KB
-
-	// sendSocketTimeout is the timeout used for context cancellation on the
-	// send socket.
-	sendSocketTimeout = 1000 * time.Millisecond
 )
 
 // ClientStatus is a description of the connection status of the client.
@@ -121,11 +109,9 @@ func (c ClientStatus) String() string {
 type ClientConn struct {
 	*connKit
 
-	receiveSocket *websocket.Conn
-	receiveMu     sync.Mutex
-
-	sendSocket *websocket.Conn
-	sendMu     sync.Mutex
+	transport ClientConnTransport
+	receiveMu sync.Mutex
+	sendMu    sync.Mutex
 
 	gbnConn    *gbn.GoBackNConn
 	gbnOptions []gbn.Option
@@ -147,12 +133,18 @@ func NewClientConn(ctx context.Context, sid [64]byte, serverHost string,
 
 	receiveSID := GetSID(sid, true)
 	sendSID := GetSID(sid, false)
+	mailBoxInfo := &mailboxInfo{
+		addr:    serverHost,
+		recvSID: receiveSID[:],
+		sendSID: sendSID[:],
+	}
 
 	log.Debugf("New client conn, read_stream=%x, write_stream=%x",
 		receiveSID[:], sendSID[:])
 
 	ctxc, cancel := context.WithCancel(ctx)
 	c := &ClientConn{
+		transport: newWebsocketTransport(mailBoxInfo),
 		gbnOptions: []gbn.Option{
 			gbn.WithTimeout(gbnTimeout),
 			gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
@@ -203,6 +195,7 @@ func RefreshClientConn(ctx context.Context, c *ClientConn) (*ClientConn,
 		c.receiveSID[:], c.sendSID[:])
 
 	cc := &ClientConn{
+		transport:   c.transport.Refresh(),
 		status:      ClientStatusNotConnected,
 		onNewStatus: c.onNewStatus,
 		gbnOptions:  c.gbnOptions,
@@ -275,10 +268,11 @@ func statusFromError(err error) ClientStatus {
 // independently of the ClientConn.
 func (c *ClientConn) recv(ctx context.Context) ([]byte, error) {
 	c.receiveMu.Lock()
-	if c.receiveSocket == nil {
+	defer c.receiveMu.Unlock()
+
+	if !c.transport.ReceiveConnected() {
 		c.createReceiveMailBox(ctx, 0)
 	}
-	c.receiveMu.Unlock()
 
 	for {
 		select {
@@ -289,38 +283,28 @@ func (c *ClientConn) recv(ctx context.Context) ([]byte, error) {
 		default:
 		}
 
-		c.receiveMu.Lock()
-		_, msg, err := c.receiveSocket.Read(ctx)
+		var (
+			msg       []byte
+			retry     bool
+			errStatus ClientStatus
+			err       error
+		)
+		msg, retry, errStatus, err = c.transport.Recv(ctx)
 		if err != nil {
-			log.Debugf("Client: got failure on receive socket, "+
-				"re-trying: %v", err)
+			if !retry {
+				return nil, err
+			}
 
-			c.setStatus(ClientStatusNotConnected)
+			log.Debugf("Client: got failure on receive "+
+				"socket/stream, re-trying: %v", err)
+
+			c.setStatus(errStatus)
 			c.createReceiveMailBox(ctx, retryWait)
-			c.receiveMu.Unlock()
 			continue
-		}
-		unwrapped, err := stripJSONWrapper(string(msg))
-		if err != nil {
-			log.Debugf("Client: got error message from receive "+
-				"socket: %v", err)
-
-			c.setStatus(statusFromError(err))
-			c.createReceiveMailBox(ctx, retryWait)
-			c.receiveMu.Unlock()
-			continue
-		}
-		c.receiveMu.Unlock()
-
-		mailboxMsg := &hashmailrpc.CipherBox{}
-		err = defaultMarshaler.Unmarshal([]byte(unwrapped), mailboxMsg)
-		if err != nil {
-			return nil, err
 		}
 
 		c.setStatus(ClientStatusConnected)
-
-		return mailboxMsg.Msg, nil
+		return msg, nil
 	}
 }
 
@@ -329,12 +313,13 @@ func (c *ClientConn) recv(ctx context.Context) ([]byte, error) {
 // cancellation of a context so that the gbn connection is able to close
 // independently of the ClientConn.
 func (c *ClientConn) send(ctx context.Context, payload []byte) error {
-	// Set up the send-socket if it has not yet been initialized.
 	c.sendMu.Lock()
-	if c.sendSocket == nil {
+	defer c.sendMu.Unlock()
+
+	// Set up the send-socket if it has not yet been initialized.
+	if !c.transport.SendConnected() {
 		c.createSendMailBox(ctx, 0)
 	}
-	c.sendMu.Unlock()
 
 	// Retry sending the payload to the hashmail server until it succeeds.
 	for {
@@ -346,34 +331,26 @@ func (c *ClientConn) send(ctx context.Context, payload []byte) error {
 		default:
 		}
 
-		sendInit := &hashmailrpc.CipherBox{
-			Desc: &hashmailrpc.CipherBoxDesc{
-				StreamId: c.sendSID[:],
-			},
-			Msg: payload,
-		}
-
-		sendInitBytes, err := defaultMarshaler.Marshal(sendInit)
-		if err != nil {
-			return err
-		}
-
-		c.sendMu.Lock()
-		ctxt, cancel := context.WithTimeout(ctx, sendSocketTimeout)
-		err = c.sendSocket.Write(
-			ctxt, websocket.MessageText, sendInitBytes,
+		var (
+			retry     bool
+			errStatus ClientStatus
+			err       error
 		)
-		cancel()
+		retry, errStatus, err = c.transport.Send(
+			ctx, c.sendSID[:], payload,
+		)
 		if err != nil {
-			log.Debugf("Client: got failure on send socket, "+
-				"re-trying: %v", err)
+			if !retry {
+				return err
+			}
 
-			c.setStatus(statusFromError(err))
+			log.Debugf("Client: got failure on send "+
+				"socket/stream, re-trying: %v", err)
+
+			c.setStatus(errStatus)
 			c.createSendMailBox(ctx, retryWait)
-			c.sendMu.Unlock()
 			continue
 		}
-		c.sendMu.Unlock()
 
 		return nil
 	}
@@ -400,38 +377,9 @@ func (c *ClientConn) createReceiveMailBox(ctx context.Context,
 
 		waiter.Wait()
 
-		receiveAddr := fmt.Sprintf(
-			addrFormat, c.serverAddr, receivePath,
-		)
-		receiveSocket, _, err := websocket.Dial(ctx, receiveAddr, nil)
-		if err != nil {
-			log.Debugf("Client: error creating receive socket %v",
-				err)
-
-			continue
-		}
-		receiveSocket.SetReadLimit(webSocketRecvLimit)
-		c.receiveSocket = receiveSocket
-
-		receiveInit := &hashmailrpc.CipherBoxDesc{
-			StreamId: c.receiveSID[:],
-		}
-		receiveInitBytes, err := defaultMarshaler.Marshal(receiveInit)
-		if err != nil {
-			log.Debugf("Client: error marshaling receive init "+
-				"bytes %w", err)
-
-			continue
-		}
-
-		ctxt, cancel := context.WithTimeout(ctx, sendSocketTimeout)
-		err = c.receiveSocket.Write(
-			ctxt, websocket.MessageText, receiveInitBytes,
-		)
-		cancel()
-		if err != nil {
-			log.Debugf("Client: error creating receive stream "+
-				"%v", err)
+		if err := c.transport.ConnectReceive(ctx); err != nil {
+			log.Errorf("Client: error connecting to receive " +
+				"socket/stream: %v")
 
 			continue
 		}
@@ -459,17 +407,14 @@ func (c *ClientConn) createSendMailBox(ctx context.Context,
 
 		waiter.Wait()
 
-		log.Debugf("Client: Attempting to create send socket")
-		sendAddr := fmt.Sprintf(addrFormat, c.serverAddr, sendPath)
-		sendSocket, _, err := websocket.Dial(ctx, sendAddr, nil)
-		if err != nil {
-			log.Debugf("Client: error creating send socket %v", err)
+		log.Debugf("Client: Attempting to create send socket/stream")
+		if err := c.transport.ConnectSend(ctx); err != nil {
+			log.Debugf("Client: error connecting to send "+
+				"stream/socket %v", err)
 			continue
 		}
 
-		c.sendSocket = sendSocket
-
-		log.Debugf("Client: Send socket created")
+		log.Debugf("Client: Connected to send socket/stream")
 		return
 	}
 }
@@ -528,31 +473,18 @@ func (c *ClientConn) Close() error {
 		}
 
 		c.receiveMu.Lock()
-		if c.receiveSocket != nil {
-			log.Debugf("sending bye on receive socket")
-			err := c.receiveSocket.Close(
-				websocket.StatusNormalClosure, "bye",
-			)
-			if err != nil {
-				log.Errorf("Error closing receive socket: %v",
-					err)
-
-				returnErr = err
-			}
+		log.Debugf("closing receive stream/socket")
+		if err := c.transport.CloseReceive(); err != nil {
+			log.Errorf("Error closing receive stream/socket: %v", err)
+			returnErr = err
 		}
 		c.receiveMu.Unlock()
 
 		c.sendMu.Lock()
-		if c.sendSocket != nil {
-			log.Debugf("sending bye on send socket")
-			err := c.sendSocket.Close(
-				websocket.StatusNormalClosure, "bye",
-			)
-			if err != nil {
-				log.Errorf("Error closing send socket: %v", err)
-
-				returnErr = err
-			}
+		log.Debugf("closing send stream/socket")
+		if err := c.transport.CloseSend(); err != nil {
+			log.Errorf("Error closing send stream/socket: %v", err)
+			returnErr = err
 		}
 		c.sendMu.Unlock()
 

--- a/mailbox/client_transport.go
+++ b/mailbox/client_transport.go
@@ -1,0 +1,231 @@
+package mailbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lightninglabs/lightning-node-connect/hashmailrpc"
+	"nhooyr.io/websocket"
+)
+
+const (
+	// webSocketRecvLimit is used to set the websocket receive limit. The
+	// default value of 32KB is enough due to the fact that grpc has a
+	// default packet maximum of 32KB which we then further wrap in gbn and
+	// hashmail messages.
+	webSocketRecvLimit int64 = 100 * 1024 // 100KB
+
+	// sendSocketTimeout is the timeout used for context cancellation on the
+	// send socket.
+	sendSocketTimeout = 1000 * time.Millisecond
+)
+
+// ClientConnTransport is an interface that hides the implementation of the
+// underlying send and receive connections to a hashmail server.
+type ClientConnTransport interface {
+	// Refresh creates a new ClientConnTransport with no initialised send
+	// or receive connections.
+	Refresh() ClientConnTransport
+
+	// ReceiveConnected returns true if the transport is connected to the
+	// hashmail-server receive stream.
+	ReceiveConnected() bool
+
+	// SendConnected returns true if the transport is connected to the
+	// hashmail-server send stream.
+	SendConnected() bool
+
+	// ConnectReceive can be called in order to initialise the
+	// receive-stream with the hashmail-server.
+	ConnectReceive(ctx context.Context) error
+
+	// ConnectSend can be called in order to initialise the send-stream with
+	// the hashmail-server.
+	ConnectSend(ctx context.Context) error
+
+	// Recv will attempt to read data off of the underlying transport's
+	// receive stream.
+	Recv(ctx context.Context) ([]byte, bool, ClientStatus, error)
+
+	// Send will attempt to send data on the underlying transport's send
+	// stream.
+	Send(ctx context.Context, streamID, payload []byte) (bool, ClientStatus,
+		error)
+
+	// CloseReceive will close the transport's connection to the
+	// receive-stream.
+	CloseReceive() error
+
+	// CloseSend will close the transport's connection to the send-stream.
+	CloseSend() error
+}
+
+// mailboxInfo holds all the mailbox related info required in order to connect
+// the correct read and write streams required to establish an LNC connection.
+type mailboxInfo struct {
+	addr    string
+	recvSID []byte
+	sendSID []byte
+}
+
+// websocketTransport is an implementation of ClientConnTransport that uses
+// websocket connections to connect to the mailbox.
+type websocketTransport struct {
+	*mailboxInfo
+	receiveSocket *websocket.Conn
+	sendSocket    *websocket.Conn
+}
+
+// newWebsocketTransport constructs a new websocketTransport instance.
+func newWebsocketTransport(mbInfo *mailboxInfo) *websocketTransport {
+	return &websocketTransport{mailboxInfo: mbInfo}
+}
+
+// Refresh creates a new ClientConnTransport with no initialised send
+// or receive connections.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) Refresh() ClientConnTransport {
+	return &websocketTransport{
+		mailboxInfo: wt.mailboxInfo,
+	}
+}
+
+// ReceiveConnected returns true if the transport is connected to the
+// hashmail-server receive stream.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) ReceiveConnected() bool {
+	return wt.receiveSocket != nil
+}
+
+// SendConnected returns true if the transport is connected to the
+// hashmail-server send stream.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) SendConnected() bool {
+	return wt.sendSocket != nil
+}
+
+// ConnectSend can be called in order to initialise the send-stream with
+// the hashmail-server.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) ConnectSend(ctx context.Context) error {
+	sendAddr := fmt.Sprintf(addrFormat, wt.addr, sendPath)
+	sendSocket, _, err := websocket.Dial(ctx, sendAddr, nil)
+	if err != nil {
+		return err
+	}
+
+	wt.sendSocket = sendSocket
+	return nil
+}
+
+// ConnectReceive can be called in order to initialise the receive-stream with
+// the hashmail-server.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) ConnectReceive(ctx context.Context) error {
+	receiveAddr := fmt.Sprintf(addrFormat, wt.addr, receivePath)
+	receiveSocket, _, err := websocket.Dial(ctx, receiveAddr, nil)
+	if err != nil {
+		return err
+	}
+
+	receiveSocket.SetReadLimit(webSocketRecvLimit)
+	wt.receiveSocket = receiveSocket
+
+	receiveInit := &hashmailrpc.CipherBoxDesc{StreamId: wt.recvSID}
+	receiveInitBytes, err := defaultMarshaler.Marshal(receiveInit)
+	if err != nil {
+		return fmt.Errorf("error marshaling receive init bytes %v", err)
+	}
+
+	ctxt, cancel := context.WithTimeout(ctx, sendSocketTimeout)
+	err = wt.receiveSocket.Write(
+		ctxt, websocket.MessageText, receiveInitBytes,
+	)
+	cancel()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Recv will attempt to read data off of the underlying transport's
+// receive-stream.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) Recv(ctx context.Context) ([]byte, bool,
+	ClientStatus, error) {
+
+	_, msg, err := wt.receiveSocket.Read(ctx)
+	if err != nil {
+		return nil, true, ClientStatusNotConnected, err
+	}
+
+	unwrapped, err := stripJSONWrapper(string(msg))
+	if err != nil {
+		return nil, true, statusFromError(err), err
+	}
+
+	mailboxMsg := &hashmailrpc.CipherBox{}
+	err = defaultMarshaler.Unmarshal([]byte(unwrapped), mailboxMsg)
+	if err != nil {
+		return nil, false, ClientStatusNotConnected, err
+	}
+
+	return mailboxMsg.Msg, false, ClientStatusConnected, nil
+}
+
+// Send will attempt to send data on the underlying transport's send-stream.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) Send(ctx context.Context, streamID,
+	payload []byte) (bool, ClientStatus, error) {
+
+	sendInit := &hashmailrpc.CipherBox{
+		Desc: &hashmailrpc.CipherBoxDesc{
+			StreamId: streamID,
+		},
+		Msg: payload,
+	}
+
+	sendInitBytes, err := defaultMarshaler.Marshal(sendInit)
+	if err != nil {
+		return false, ClientStatusNotConnected, err
+	}
+
+	ctxt, cancel := context.WithTimeout(ctx, sendSocketTimeout)
+	err = wt.sendSocket.Write(ctxt, websocket.MessageText, sendInitBytes)
+	cancel()
+	if err != nil {
+		return true, statusFromError(err), err
+	}
+
+	return false, ClientStatusConnected, nil
+}
+
+// CloseReceive will close the transport's connection to the receive-stream.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) CloseReceive() error {
+	if wt.receiveSocket == nil {
+		return nil
+	}
+	return wt.receiveSocket.Close(websocket.StatusNormalClosure, "bye")
+}
+
+// CloseSend will close the transport's connection to the send-stream.
+//
+// NOTE: this is part of the ClientConnTransport interface.
+func (wt *websocketTransport) CloseSend() error {
+	if wt.sendSocket == nil {
+		return nil
+	}
+
+	return wt.sendSocket.Close(websocket.StatusNormalClosure, "bye")
+}


### PR DESCRIPTION
In this PR, the underlying transport used by the `ClientConn` is abstracted into an interface so that a grpc implementation could be added as well (currently, the only option is to use websockets). Changes are also made to the itests so that both implementation are tested.