### PR TITLE
wasm: update HasPermissions to account for custom perms

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -189,8 +189,11 @@ Add the following polyfill for Microsoft Edge 17/18 support:
         }
 
         // Determine if the session is a read only session.
-        let readOnly = window[namespace].wasmClientIsReadOnly();
-        if (readOnly) {
+        let readOnlySession = window[namespace].wasmClientIsReadOnly();
+        let customSession = window[namespace].wasmClientIsCustom();
+        if (customSession) {
+            document.getElementById('sessiontype').textContent = "This is a Custom Session"
+        } else if (readOnlySession) {
             document.getElementById('sessiontype').textContent = "This is a Read-Only Session"
         } else {
             document.getElementById('sessiontype').textContent = "This is an Admin Session"


### PR DESCRIPTION
This commit updates the HasPermissions function to account for the case where the session has custom permissions which would specify "uri" as the permission entity and the actual URI as the permission action.

works with https://github.com/lightninglabs/lightning-terminal/pull/438