### PR TITLE
itest: export HashmailHarness struct

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,16 @@ linters-settings:
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    lines: 200
+    # Checks the number of statements in a function.
+    statements: 80
+  gosec:
+    excludes:
+      - G402 # Look for bad TLS connection settings.
+      - G306 # Poor file permissions used when writing to a new file.
 
 linters:
   enable-all: true
@@ -32,16 +42,49 @@ linters:
     # them even longer by marking them as 'nolint'.
     - lll
 
-    # We don't care (enough) about misaligned structs to lint that.
+    # We don't require that all structs have all fields initialized when new
+    # instances are created.
+    - exhaustruct
+
+    # Deprecated linters. See https://golangci-lint.run/usage/linters/.
+    - interfacer
+    - golint
     - maligned
-
-    # We have long functions, especially in tests. Moving or renaming those
-    # would trigger funlen problems that we may not want to solve at that time.
-    - funlen
-
-    # Gosec is outdated and reports false positives.
-    - gosec
+    - scopelint
+    - exhaustivestruct
+    - bodyclose
+    - contextcheck
+    - nilerr
+    - noctx
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - tparallel
+    - unparam
+    - wastedassign
+    - ifshort
+    - varcheck
+    - deadcode
+    - nosnakecase
 
 issues:
   # Only show newly introduced problems.
   new-from-rev: 4008b92d81d4d62e663025c5f79ebe44b53f283c
+
+  exclude-rules:
+    # Exclude gosec from running for tests so that tests with weak randomness
+    # (math/rand) will pass the linter. We also exclude funlen from tests as
+    # have test functions that are intentionally long.
+    - path: _test\.go
+      linters:
+        - gosec
+        - funlen
+
+    - path: test*
+      linters:
+        - gosec
+        - funlen
+
+    - path: itest/.*
+      linters:
+        - paralleltest

--- a/itest/connection_test.go
+++ b/itest/connection_test.go
@@ -45,14 +45,14 @@ func testHashmailServerReconnect(t *harnessTest) {
 	require.Equal(t.t, len(defaultMessage)*10, len(resp.Resp))
 
 	// Shut down hashmail server
-	require.NoError(t.t, t.hmserver.stop())
+	require.NoError(t.t, t.hmserver.Stop())
 
 	// Check that the client and server status are updated appropriately.
 	assertServerStatus(t, mailbox.ServerStatusNotConnected)
 	assertClientStatus(t, mailbox.ClientStatusNotConnected)
 
 	// Restart hashmail server
-	require.NoError(t.t, t.hmserver.start())
+	require.NoError(t.t, t.hmserver.Start())
 
 	// Check that the client and server successfully reconnect.
 	assertServerStatus(t, mailbox.ServerStatusInUse)

--- a/itest/hashmailserver_harness.go
+++ b/itest/hashmailserver_harness.go
@@ -12,14 +12,17 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/wait"
 )
 
-type hashmailHarness struct {
-	aperture    *aperture.Aperture
-	apertureCfg *aperture.Config
+type HashmailHarness struct {
+	aperture *aperture.Aperture
+
+	// ApertureCfg is the configuration aperture uses when being initialized.
+	ApertureCfg *aperture.Config
 }
 
-func newHashmailHarness() *hashmailHarness {
-	return &hashmailHarness{
-		apertureCfg: &aperture.Config{
+// NewHashmailHarness creates a new instance of the HashmailHarness.
+func NewHashmailHarness() *HashmailHarness {
+	return &HashmailHarness{
+		ApertureCfg: &aperture.Config{
 			ListenAddr: fmt.Sprintf("127.0.0.1:%d",
 				node.NextAvailablePort()),
 			Authenticator: &aperture.AuthConfig{
@@ -39,8 +42,8 @@ func newHashmailHarness() *hashmailHarness {
 }
 
 // initAperture starts the aperture proxy.
-func (hm *hashmailHarness) initAperture() error {
-	hm.aperture = aperture.NewAperture(hm.apertureCfg)
+func (hm *HashmailHarness) initAperture() error {
+	hm.aperture = aperture.NewAperture(hm.ApertureCfg)
 	errChan := make(chan error)
 
 	if err := hm.aperture.Start(errChan); err != nil {
@@ -60,7 +63,7 @@ func (hm *hashmailHarness) initAperture() error {
 	}
 	return wait.NoError(func() error {
 		apertureAddr := fmt.Sprintf("https://%s/dummy",
-			hm.apertureCfg.ListenAddr)
+			hm.ApertureCfg.ListenAddr)
 
 		resp, err := http.Get(apertureAddr)
 		if err != nil {
@@ -75,7 +78,8 @@ func (hm *hashmailHarness) initAperture() error {
 	}, 3*time.Second)
 }
 
-func (hm *hashmailHarness) start() error {
+// Start attempts to start the aperture proxy.
+func (hm *HashmailHarness) Start() error {
 	if err := hm.initAperture(); err != nil {
 		return fmt.Errorf("could not start aperture: %v", err)
 	}
@@ -83,6 +87,7 @@ func (hm *hashmailHarness) start() error {
 	return nil
 }
 
-func (hm *hashmailHarness) stop() error {
+// Stop attempts to stop the aperture proxy.
+func (hm *HashmailHarness) Stop() error {
 	return hm.aperture.Stop()
 }

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -44,7 +44,7 @@ type harnessTest struct {
 
 	server *serverHarness
 
-	hmserver *hashmailHarness
+	hmserver *HashmailHarness
 }
 
 // testConfig determines the way in which the test will be set up.
@@ -61,11 +61,11 @@ func newHarnessTest(t *testing.T, cfg *testConfig) *harnessTest {
 	mailboxAddr := testnetMailbox
 	var insecure bool
 	if !cfg.stagingMailbox {
-		ht.hmserver = newHashmailHarness()
-		if err := ht.hmserver.start(); err != nil {
+		ht.hmserver = NewHashmailHarness()
+		if err := ht.hmserver.Start(); err != nil {
 			t.Fatalf("could not start hashmail server: %v", err)
 		}
-		mailboxAddr = ht.hmserver.apertureCfg.ListenAddr
+		mailboxAddr = ht.hmserver.ApertureCfg.ListenAddr
 		insecure = true
 	}
 
@@ -186,7 +186,7 @@ func (h *harnessTest) shutdown() error {
 	h.server.stop()
 
 	if h.hmserver != nil {
-		err := h.hmserver.stop()
+		err := h.hmserver.Stop()
 		if err != nil {
 			returnErr = err
 		}

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -60,11 +60,14 @@ func newHarnessTest(t *testing.T, cfg *testConfig) *harnessTest {
 
 	mailboxAddr := testnetMailbox
 	var insecure bool
+
 	if !cfg.stagingMailbox {
 		ht.hmserver = NewHashmailHarness()
+
 		if err := ht.hmserver.Start(); err != nil {
 			t.Fatalf("could not start hashmail server: %v", err)
 		}
+
 		mailboxAddr = ht.hmserver.ApertureCfg.ListenAddr
 		insecure = true
 	}


### PR DESCRIPTION
This PR exports the `HashmailHarness` struct, so that it can be used as an external dependency to setup a local mail server.