### PR TITLE
gbn: Sender side only packeting resend bug fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,10 @@ linters:
     # guidelines. See https://github.com/mvdan/gofumpt/issues/235.
     - gofumpt
 
+    # Disable gomnd even though we generally don't use magic numbers, but there
+    # are exceptions where this improves readability.
+    - gomnd
+
     # Disable whitespace linter as it has conflict rules against our
     # contribution guidelines. See https://github.com/bombsimon/wsl/issues/109.
     #

--- a/gbn/config.go
+++ b/gbn/config.go
@@ -38,6 +38,10 @@ type config struct {
 	// packet.
 	sendToStream sendBytesFunc
 
+	// onFIN is a callback that if set, will be called once a FIN packet has
+	// been received and processed.
+	onFIN func()
+
 	// handshakeTimeout is the time after which the server or client
 	// will abort and restart the handshake if the expected response is
 	// not received from the peer.

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -582,15 +582,12 @@ func (g *GoBackNConn) receivePacketsForever() error { // nolint:gocyclo
 			// sent was dropped, or maybe we sent a duplicate
 			// message. The NACK message contains the sequence
 			// number that the receiver was expecting.
-			inQueue, bumped := g.sendQueue.processNACK(m.Seq)
+			shouldResend, bumped := g.sendQueue.processNACK(m.Seq)
 
-			// If the NACK sequence number is not in our queue
-			// then we ignore it. We must have received the ACK
-			// for the sequence number in the meantime.
-			if !inQueue {
-				g.log.Tracef("NACK seq %d is not in the "+
-					"queue. Ignoring", m.Seq)
-
+			// If we don't need to resend the queue after processing
+			// the NACK, we can continue without sending the resend
+			// signal.
+			if !shouldResend {
 				continue
 			}
 

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -514,6 +514,8 @@ func (g *GoBackNConn) receivePacketsForever() error { // nolint:gocyclo
 			g.pongTicker.Pause()
 		}
 
+		g.resendTicker.Reset(g.cfg.resendTimeout)
+
 		switch m := msg.(type) {
 		case *PacketData:
 			switch m.Seq == g.recvSeq {
@@ -588,8 +590,6 @@ func (g *GoBackNConn) receivePacketsForever() error { // nolint:gocyclo
 		case *PacketACK:
 			gotValidACK := g.sendQueue.processACK(m.Seq)
 			if gotValidACK {
-				g.resendTicker.Reset(g.cfg.resendTimeout)
-
 				// Send a signal to indicate that new
 				// ACKs have been received.
 				select {

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -649,6 +649,10 @@ func (g *GoBackNConn) receivePacketsForever() error { // nolint:gocyclo
 
 			close(g.remoteClosed)
 
+			if g.cfg.onFIN != nil {
+				g.cfg.onFIN()
+			}
+
 			return errTransportClosing
 
 		default:

--- a/gbn/options.go
+++ b/gbn/options.go
@@ -43,3 +43,11 @@ func WithKeepalivePing(ping, pong time.Duration) Option {
 		conn.pongTime = pong
 	}
 }
+
+// WithOnFIN is used to set the onFIN callback that will be called once a FIN
+// packet has been received and processed.
+func WithOnFIN(fn func()) Option {
+	return func(conn *config) {
+		conn.onFIN = fn
+	}
+}

--- a/gbn/queue_test.go
+++ b/gbn/queue_test.go
@@ -1,8 +1,11 @@
 package gbn
 
 import (
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,4 +21,132 @@ func TestQueueSize(t *testing.T) {
 	q.sequenceBase = 3
 	q.sequenceTop = 2
 	require.Equal(t, uint8(3), q.size())
+}
+
+// TestQueueResend tests that the queue resend functionality works as expected.
+// It specifically tests that we actually resend packets, and await the expected
+// durations for cases when we resend and 1) don't receive the expected
+// ACK/NACK, 2) receive the expected ACK, and 3) receive the expected NACK.
+func TestQueueResend(t *testing.T) {
+	t.Parallel()
+
+	resentPackets := make(map[uint8]struct{})
+	queueTimeout := time.Second * 1
+
+	cfg := &queueCfg{
+		s:       5,
+		timeout: queueTimeout,
+		sendPkt: func(packet *PacketData) error {
+			resentPackets[packet.Seq] = struct{}{}
+
+			return nil
+		},
+	}
+	q := newQueue(cfg)
+
+	pkt1 := &PacketData{Seq: 1}
+	pkt2 := &PacketData{Seq: 2}
+	pkt3 := &PacketData{Seq: 3}
+
+	q.addPacket(pkt1)
+
+	// First test that we shouldn't resend if the timeout hasn't passed.
+	q.lastResend = time.Now()
+
+	err := q.resend()
+	require.NoError(t, err)
+
+	require.Empty(t, resentPackets)
+
+	// Secondly, let's test that we do resend if the timeout has passed, and
+	// that we then start a sync once we've resent the packet.
+	q.lastResend = time.Now().Add(-queueTimeout * 2)
+
+	// Let's first test the syncing scenario where we don't receive
+	// the expected ACK/NACK for the resent packet. This should trigger a
+	// timeout of the syncing, which should be the
+	// queueTimeout * awaitingTimeoutMultiplier.
+	startTime := time.Now()
+
+	var wg sync.WaitGroup
+	resend(t, q, &wg)
+
+	wg.Wait()
+
+	// Check that the resend took at least the
+	// queueTimeout * awaitingTimeoutMultiplier for the syncing to
+	// complete, and that we actually resent the packet.
+	require.GreaterOrEqual(
+		t, time.Since(startTime),
+		queueTimeout*awaitingTimeoutMultiplier,
+	)
+	require.Contains(t, resentPackets, pkt1.Seq)
+
+	// Now let's test the syncing scenario where we do receive the
+	// expected ACK for the resent packet. This should trigger a
+	// queue.proceedAfterTime call, which should finish the syncing
+	// after the queueTimeout.
+	q.lastResend = time.Now().Add(-queueTimeout * 2)
+
+	q.addPacket(pkt2)
+
+	startTime = time.Now()
+
+	resend(t, q, &wg)
+
+	// Simulate that we receive the expected ACK for the resent packet.
+	q.processACK(pkt2.Seq)
+
+	wg.Wait()
+
+	// Now check that the resend took at least the queueTimeout for the
+	// syncing to complete, and that we actually resent the packet.
+	require.GreaterOrEqual(t, time.Since(startTime), queueTimeout)
+	require.LessOrEqual(t, time.Since(startTime), queueTimeout*2)
+	require.Contains(t, resentPackets, pkt2.Seq)
+
+	// Finally, let's test the syncing scenario where we do receive the
+	// expected NACK for the resent packet. This make the syncing
+	// complete immediately.
+	q.lastResend = time.Now().Add(-queueTimeout * 2)
+
+	q.addPacket(pkt3)
+
+	startTime = time.Now()
+	resend(t, q, &wg)
+
+	// Simulate that we receive the expected NACK for the resent packet.
+	q.processNACK(pkt3.Seq + 1)
+
+	wg.Wait()
+
+	// Finally let's check that we didn't await any timeout now, and that
+	// we actually resent the packet.
+	require.Less(t, time.Since(startTime), queueTimeout)
+	require.Contains(t, resentPackets, pkt3.Seq)
+}
+
+// resend is a helper function that resends packets in a goroutine, and notifies
+// the WaitGroup when the resend + syncing has completed.
+// The function will block until the resend has actually started.
+func resend(t *testing.T, q *queue, wg *sync.WaitGroup) {
+	t.Helper()
+
+	wg.Add(1)
+
+	// This will trigger a sync, so we launch the resend in a
+	// goroutine.
+	go func() {
+		err := q.resend()
+		require.NoError(t, err)
+
+		wg.Done()
+	}()
+
+	// We also ensure that the above goroutine is has started the resend
+	// before this function returns.
+	err := wait.Predicate(func() bool {
+		return q.syncer.getState() == syncStateResending
+	}, time.Second)
+	require.NoError(t, err)
 }

--- a/gbn/queue_test.go
+++ b/gbn/queue_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestQueueSize(t *testing.T) {
-	q := newQueue(4, 0, nil)
+	q := newQueue(&queueCfg{s: 4})
 
 	require.Equal(t, uint8(0), q.size())
 

--- a/gbn/syncer.go
+++ b/gbn/syncer.go
@@ -1,0 +1,306 @@
+package gbn
+
+import (
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btclog"
+)
+
+const (
+	// awaitingTimeoutMultiplier defines the multiplier we use when
+	// multiplying the resend timeout, resulting in the duration we wait for
+	// the sync to be complete before timing out.
+	// We set this to 3X the resend timeout. The reason we wait exactly 3X
+	// the resend timeout is that we expect that the max time that the
+	// correct behavior would take, would be:
+	// * 1X the resendTimeout for the time it would take for the party
+	// respond with an ACK for the last packet in the resend queue, i.e. the
+	// expectedACK.
+	// * 1X the resendTimeout while waiting in proceedAfterTime before
+	// completing the sync.
+	// * 1X extra resendTimeout as buffer, to ensure that we have enough
+	// time to process the ACKS/NACKS by other party + some extra margin.
+	awaitingTimeoutMultiplier = 3
+)
+
+type syncState uint8
+
+const (
+	// syncStateIdle is the state representing that the syncer is idle and
+	// has not yet initiated a resend sync.
+	syncStateIdle syncState = iota
+
+	// syncStateResending is the state representing that the syncer has
+	// initiated a resend sync, and is awaiting that the sync is completed.
+	syncStateResending
+)
+
+// syncer is used to ensure that both the sender and the receiver are in sync
+// before the waitForSync function is completed. This is done by waiting until
+// we receive either the expected ACK or NACK after resending the queue.
+//
+// To understand why we need to wait for the expected ACK/NACK after resending
+// the queue, it ensures that we don't end up in a situation where we resend the
+// queue over and over again due to latency and delayed NACKs by the other
+// party.
+//
+// Consider the following scenario:
+// 1.
+// Alice sends packets 1, 2, 3 & 4 to Bob.
+// 2.
+// Bob receives packets 1, 2, 3 & 4, and sends back the respective ACKs.
+// 3.
+// Alice receives ACKs for packets 1 & 2, but due to latency the ACKs for
+// packets 3 & 4 are delayed and aren't received until Alice resend timeout
+// has passed, which leads to Alice resending packets 3 & 4. Alice will after
+// that receive the delayed ACKs for packets 3 & 4, but will consider that as
+// the ACKs for the resent packets, and not the original packets which they were
+// actually sent for. If we didn't wait after resending the queue, Alice would
+// then proceed to send more packets (5 & 6).
+// 4.
+// When Bob receives the resent packets 3 & 4, Bob will respond with NACK 5. Due
+// to latency, the packets 5 & 6 that Alice sent in step (3) above will then be
+// received by Bob, and be processed as the correct response to the NACK 5. Bob
+// will after that await packet 7.
+// 5.
+// Alice will receive the NACK 5, and now resend packets 5 & 6. But as Bob is
+// now awaiting packet 7, this send will lead to a NACK 7. But due to latency,
+// if Alice doesn't wait resending the queue, Alice will proceed to send new
+// packet(s) before receiving the NACK 7.
+// 6.
+// This resend loop would continue indefinitely, so we need to ensure that Alice
+// waits after she has resent the queue, to ensure that she doesn't proceed to
+// send new packets before she is sure that both parties are in sync.
+//
+// To ensure that we are in sync, after we have resent the queue, we will await
+// that we either:
+// 1. Receive a NACK for the sequence number succeeding the last packet in the
+// resent queue i.e. in step (3) above, that would be NACK 5.
+// OR
+// 2. Receive an ACK for the last packet in the resent queue i.e. in step (3)
+// above, that would be ACK 4. After we receive the expected ACK, we will then
+// wait for the duration of the resend timeout before continuing. The reason why
+// we wait for the resend timeout before continuing, is that the ACKs we are
+// getting after a resend, could be delayed ACKs for the original packets we
+// sent, and not ACKs for the resent packets. In step (3) above, the ACKs for
+// packets 3 & 4 that Alice received were delayed ACKs for the original packets.
+// If Alice would have immediately continued to send new packets (5 & 6) after
+// receiving the ACK 4, she would have then received the NACK 5 from Bob which
+// was the actual response to the resent queue. But as Alice had already
+// continued to send packets 5 & 6 when receiving the NACK 5, the resend queue
+// response to that NACK would cause the resend loop to continue indefinitely.
+// OR
+// 3. If neither of condition 1 or 2 above is met within 3X the resend timeout,
+// we will time out and consider the sync to be completed. See the docs for
+// awaitingTimeoutMultiplier for more details on why we wait 3X the resend
+// timeout.
+//
+// When either of the 3 conditions above are met, we will consider both parties
+// to be in sync.
+type syncer struct {
+	s       uint8
+	log     btclog.Logger
+	timeout time.Duration
+
+	state syncState
+
+	// expectedACK defines the sequence number for the last packet in the
+	// resend queue. If we receive an ACK for this sequence number while
+	// waiting to sync, we wait for the duration of the resend timeout,
+	// and then proceed to send new packets, unless we receive the
+	// expectedNACK during the wait time. If that happens, we will proceed
+	// to send new packets as soon as we have processed the NACK.
+	expectedACK uint8
+
+	// expectedNACK is set to the sequence number that follows the last item
+	// in resend queue, when a sync is initiated. In case we get a NACK with
+	// this sequence number when waiting to sync, we'd consider the sync to
+	// be completed and we can proceed to send new packets.
+	expectedNACK uint8
+
+	// cancel is used to mark that the sync has been completed.
+	cancel chan struct{}
+
+	quit chan struct{}
+	mu   sync.Mutex
+}
+
+// newSyncer creates a new syncer instance.
+func newSyncer(s uint8, prefixLogger btclog.Logger, timeout time.Duration,
+	quit chan struct{}) *syncer {
+
+	if prefixLogger == nil {
+		prefixLogger = log
+	}
+
+	return &syncer{
+		s:       s,
+		log:     prefixLogger,
+		timeout: timeout,
+		state:   syncStateIdle,
+		cancel:  make(chan struct{}),
+		quit:    quit,
+	}
+}
+
+// reset resets the syncer state to idle and marks the sync as completed.
+func (c *syncer) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.resetUnsafe()
+}
+
+// resetUnsafe resets the syncer state to idle and marks the sync as completed.
+//
+// NOTE: when calling this function, the caller must hold the syncer mutex.
+func (c *syncer) resetUnsafe() {
+	c.state = syncStateIdle
+
+	// Cancel any pending sync.
+	select {
+	case c.cancel <- struct{}{}:
+	default:
+	}
+}
+
+// initResendUpTo initializes the syncer to the resending state, and will after
+// this call be ready to wait for the sync to be completed when calling the
+// waitForSync function.
+// The top argument defines the sequence number of the next packet to be sent
+// after resending the queue.
+func (c *syncer) initResendUpTo(top uint8) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.state = syncStateResending
+
+	// Drain the cancel channel, to reinitialize it for the new sync.
+	select {
+	case <-c.cancel:
+	default:
+	}
+
+	c.expectedACK = (c.s + top - 1) % c.s
+	c.expectedNACK = top
+
+	c.log.Tracef("Set expectedACK to %d & expectedNACK to %d",
+		c.expectedACK, c.expectedNACK)
+}
+
+// getState returns the current state of the syncer.
+func (c *syncer) getState() syncState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.state
+}
+
+// waitForSync waits for the sync to be completed. The sync is completed when we
+// receive either the expectedNACK, the expectedACK + resend timeout has passed,
+// or when timing out.
+func (c *syncer) waitForSync() {
+	c.log.Tracef("Awaiting sync after resending the queue")
+
+	select {
+	case <-c.quit:
+		return
+
+	case <-c.cancel:
+		c.log.Tracef("sync canceled or reset")
+
+	case <-time.After(c.timeout * awaitingTimeoutMultiplier):
+		c.log.Tracef("Timed out while waiting for sync")
+	}
+
+	c.reset()
+}
+
+// processACK marks the sync as completed if the passed sequence number matches
+// the expectedACK, after the resend timeout has passed.
+// If we are not resending or waiting after a resend, this is a no-op.
+func (c *syncer) processACK(seq uint8) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// If we are not resending or waiting after a resend, just swallow the
+	// ACK.
+	if c.state != syncStateResending {
+		return
+	}
+
+	// Else, if we are waiting but this is not the ack we are waiting for,
+	// just swallow it.
+	if seq != c.expectedACK {
+		return
+	}
+
+	c.log.Tracef("Got expected ACK")
+
+	// We start the proceedAfterTime function in a goroutine, as we
+	// don't want to block the processing of other NACKs/ACKs while
+	// we're waiting for the resend timeout to expire.
+	go c.proceedAfterTime()
+}
+
+// processNACK marks the sync as completed if the passed sequence number matches
+// the expectedNACK.
+// If we are not resending or waiting after a resend, this is a no-op.
+func (c *syncer) processNACK(seq uint8) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// If we are not resending or waiting after a resend, just swallow the
+	// NACK.
+	if c.state != syncStateResending {
+		return
+	}
+
+	// Else, if we are waiting but this is not the NACK we are waiting for,
+	// just swallow it.
+	if seq != c.expectedNACK {
+		return
+	}
+
+	c.log.Tracef("Got expected NACK")
+
+	c.resetUnsafe()
+}
+
+// proceedAfterTime will wait for the resendTimeout and then complete the sync,
+// if we haven't completed the sync yet by receiving the expectedNACK.
+func (c *syncer) proceedAfterTime() {
+	// We await for the duration of the resendTimeout before completing the
+	// sync, as that's the time we'd expect it to take for the other party
+	// to respond with a NACK, if the resent last packet in the
+	// queue would lead to a NACK. If we receive the expectedNACK
+	// before the timeout, the cancel channel will be sent over, and we can
+	// stop the execution early.
+	select {
+	case <-c.quit:
+		return
+
+	case <-c.cancel:
+		c.log.Tracef("sync succeeded or was reset")
+
+		// As we can't be sure that waitForSync cancel listener was
+		// triggered before this one, we send over the cancel channel
+		// again, to make sure that both listeners are triggered.
+		c.reset()
+
+		return
+
+	case <-time.After(c.timeout):
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		if c.state != syncStateResending {
+			return
+		}
+
+		c.log.Tracef("Completing sync after expectedACK timeout")
+
+		c.resetUnsafe()
+	}
+}

--- a/gbn/syncer_test.go
+++ b/gbn/syncer_test.go
@@ -1,0 +1,110 @@
+package gbn
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncer tests that the syncer functionality works as expected. It
+// specifically tests that we wait the expected durations for cases when we
+// initiate resends and 1) don't receive the expected ACK/NACK, 2) receive the
+// expected ACK, and 3) receive the expected NACK.
+func TestSyncer(t *testing.T) {
+	t.Parallel()
+
+	syncTimeout := time.Second * 1
+	expectedNACK := uint8(3)
+
+	syncer := newSyncer(5, nil, syncTimeout, make(chan struct{}))
+
+	// Let's first test the scenario where we don't receive the expected
+	// ACK/NACK after initiating the resend. This should trigger a timeout
+	// of the sync, which should be the:
+	// syncTimeout * awaitingTimeoutMultiplier.
+	startTime := time.Now()
+
+	var wg sync.WaitGroup
+	initResend(t, syncer, &wg, expectedNACK)
+
+	wg.Wait()
+
+	// Check that the syncing took at least the
+	// syncTimeout * awaitingTimeoutMultiplier to complete.
+	require.GreaterOrEqual(
+		t, time.Since(startTime),
+		syncTimeout*awaitingTimeoutMultiplier,
+	)
+
+	// Now let's test the scenario where we do receive the expected ACK for
+	// the when awaiting the sync. This should trigger the
+	// syncer.proceedAfterTime call, which should finish complete the sync
+	// after the syncTimeout.
+	startTime = time.Now()
+
+	initResend(t, syncer, &wg, expectedNACK)
+
+	// Simulate that we receive the expected ACK.
+	simulateACKProcessing(t, syncer, 1, expectedNACK-1)
+
+	wg.Wait()
+
+	// Now check that the sync took at least the syncTimeout to complete.
+	require.GreaterOrEqual(t, time.Since(startTime), syncTimeout)
+	require.LessOrEqual(t, time.Since(startTime), syncTimeout*2)
+
+	// Finally, let's test the scenario where we do receive the expected
+	// NACK when syncing. This completes the sync immediately.
+	startTime = time.Now()
+
+	initResend(t, syncer, &wg, expectedNACK)
+
+	// Simulate that we receive the expected NACK.
+	syncer.processNACK(expectedNACK)
+
+	wg.Wait()
+
+	// Finally let's check that we didn't exit on the timeout in this case.
+	require.Less(t, time.Since(startTime), syncTimeout)
+}
+
+// simulateACKProcessing is a helper function that simulates the processing of
+// ACKs for the given range of sequence numbers.
+func simulateACKProcessing(t *testing.T, syncer *syncer, base, last uint8) {
+	t.Helper()
+
+	for i := base; i <= last; i++ {
+		syncer.processACK(i)
+	}
+}
+
+// initResend is a helper function that triggers an initResendUpTo for the given
+// top and then waits for the sync to complete in a goroutine, and notifies
+// the WaitGroup when the sync has completed.
+// The function will block until the initResendUpTo function has executed.
+func initResend(t *testing.T, syncer *syncer, wg *sync.WaitGroup, top uint8) {
+	t.Helper()
+
+	require.Equal(t, syncStateIdle, syncer.getState())
+
+	wg.Add(1)
+
+	// This will trigger a resend catchup, so we launch the resend in a
+	// goroutine.
+	go func() {
+		syncer.initResendUpTo(top)
+		syncer.waitForSync()
+
+		wg.Done()
+	}()
+
+	// We also ensure that the above goroutine has executed the
+	// initResendUpTo function before this function returns.
+	err := wait.Predicate(func() bool {
+		return syncer.getState() == syncStateResending
+	}, time.Second)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #89 

This PR addresses the packeting resend bug through a sender only side fix.

This PR ensures that after we have resent the queue, we will wait until we know that both parties are in sync before we continue to send new packets. This ensures that we don't end up in an indefinitely resend loop due to latency and delayed NACKs by the other party, which could happen prior to this commit.

To understand why we need to await the awaited ACK/NACK after resending the queue, consider the following scenario:

1. Alice sends packets 1, 2, 3 & 4 to Bob.
2. Bob receives packets 1, 2, 3 & 4, and sends back the respective ACKs.
3. Alice receives ACKs for packets 1 & 2, but due to latency the ACKs for packets 3 & 4 are delayed and aren't received until Alice resend timeout has passed, which leads to Alice resending packets 3 & 4. Alice will after that receive the delayed ACKs for packets 3 & 4, but will consider that as the ACKs for the resent packets, and not the original packets which they were actually sent for. If we didn't wait after resending the queue, Alice would then proceed to send more packets (5 & 6).
4. When Bob receives the resent packets 3 & 4, Bob will respond with NACK 5. Due to latency, the packets 5 & 6 that Alice sent in step (3) above will then be received by Bob, and be processed as the correct response to the NACK 5. Bob will after that await packet 7.
5. Alice will receive the NACK 5, and now resend packets 5 & 6. But as Bob is now awaiting packet 7, this send will lead to a NACK 7. But due to latency, if Alice doesn't wait resending the queue, Alice will proceed to send new packet(s) before receiving the NACK 7.
6. This resend loop would continue indefinitely, so we need to ensure that Alice waits after she has resent the queue, to ensure that she doesn't proceed to send new packets before she is sure that both parties are in sync.

To ensure that we are in sync, after we have resent the queue, we will await that we EITHER:
1. Receive a NACK for the sequence number succeeding the last packet in the resent queue i.e. in step (3) above, that would be NACK 5.
2. Receive an ACK for the last packet in the resent queue i.e. in step (3) above, that would be ACK 4. After we receive the expected ACK, we will then wait for the duration of the resend timeout before continuing. The reason why we wait for the resend timeout before continuing, is that the ACKs we are getting after a resend, could be delayed ACKs for the
original packets we sent, and not ACKs for the resent packets. In step (3) above, the ACKs for packets 3 & 4 that Alice received were delayed ACKs for the original packets. If Alice would have immediately continued to send new packets (5 & 6) after receiving the ACK 4, she would have then received the NACK 5 from Bob which was the actual response to the resent queue. But as Alice had already continued to send packets 5 & 6 when receiving the NACK 5, the resend queue response to that NACK would cause the resend loop to continue indefinitely.

When either of the 2 conditions above are met, we will consider both parties to be in sync, and we can proceed to send new packets.

TODO:
- [X] Update the with extra docs + update commit messages with more detailed docs