### PR TITLE
gbn: set resend timeout dynamically

### DIFF
--- a/gbn/config.go
+++ b/gbn/config.go
@@ -44,22 +44,22 @@ func WithTimeoutUpdateFrequency(frequency int) TimeoutOptions {
 	}
 }
 
-// WithTMHandshakeTimeout is used to set the timeout used during the handshake.
+// WithHandshakeTimeout is used to set the timeout used during the handshake.
 // If the timeout is reached without response from the peer then the handshake
 // will be aborted and restarted.
-func WithTMHandshakeTimeout(timeout time.Duration) TimeoutOptions {
+func WithHandshakeTimeout(timeout time.Duration) TimeoutOptions {
 	return func(manager *TimeoutManager) {
 		manager.handshakeTimeout = timeout
 	}
 }
 
-// WithTMKeepalivePing is used to send a ping packet if no packets have been
+// WithKeepalivePing is used to send a ping packet if no packets have been
 // received from the other side for the given duration. This helps keep the
 // connection alive and also ensures that the connection is closed if the
 // other side does not respond to the ping in a timely manner. After the ping
 // the connection will be closed if the other side does not respond within
 // time duration.
-func WithTMKeepalivePing(ping, pong time.Duration) TimeoutOptions {
+func WithKeepalivePing(ping, pong time.Duration) TimeoutOptions {
 	return func(manager *TimeoutManager) {
 		manager.pingTime = ping
 		manager.pongTime = pong
@@ -90,10 +90,6 @@ type config struct {
 	// between packets.
 	maxChunkSize int
 
-	// resendTimeout is the duration that will be waited before resending
-	// the packets in the current queue.
-	resendTimeout time.Duration
-
 	// recvFromStream is the function that will be used to acquire the next
 	// available packet.
 	recvFromStream recvBytesFunc
@@ -106,13 +102,7 @@ type config struct {
 	// been received and processed.
 	onFIN func()
 
-	// handshakeTimeout is the time after which the server or client
-	// will abort and restart the handshake if the expected response is
-	// not received from the peer.
-	handshakeTimeout time.Duration
-
-	pingTime time.Duration
-	pongTime time.Duration
+	timeoutOptions []TimeoutOptions
 }
 
 // newConfig constructs a new config struct.
@@ -120,11 +110,9 @@ func newConfig(sendFunc sendBytesFunc, recvFunc recvBytesFunc,
 	n uint8) *config {
 
 	return &config{
-		n:                n,
-		s:                n + 1,
-		recvFromStream:   recvFunc,
-		sendToStream:     sendFunc,
-		resendTimeout:    defaultResendTimeout,
-		handshakeTimeout: defaultHandshakeTimeout,
+		n:              n,
+		s:              n + 1,
+		recvFromStream: recvFunc,
+		sendToStream:   sendFunc,
 	}
 }

--- a/gbn/config.go
+++ b/gbn/config.go
@@ -2,6 +2,70 @@ package gbn
 
 import "time"
 
+// TimeoutOptions can be used to modify the default timeout values used within
+// the TimeoutManager.
+type TimeoutOptions func(manager *TimeoutManager)
+
+// WithStaticResendTimeout is used to set a static resend timeout. This is the
+// time to wait for ACKs before resending the queue.
+func WithStaticResendTimeout(timeout time.Duration) TimeoutOptions {
+	return func(manager *TimeoutManager) {
+		manager.useStaticTimeout = true
+		manager.resendTimeout = timeout
+	}
+}
+
+// WithResendMultiplier is used to set the resend multiplier. This is the
+// multiplier we use when dynamically setting the resend timeout, based on how
+// long it took for other party to respond.
+// Note that when setting the resend timeout manually with the
+// WithStaticResendTimeout option, this option will have no effect.
+// Note that the passed multiplier must be greater than zero or this option will
+// have no effect.
+func WithResendMultiplier(multiplier int) TimeoutOptions {
+	return func(manager *TimeoutManager) {
+		if multiplier > 0 {
+			manager.resendMultiplier = multiplier
+		}
+	}
+}
+
+// WithTimeoutUpdateFrequency is used to set the frequency of how many
+// corresponding responses we need to receive until updating the resend timeout.
+// Note that when setting the resend timeout manually with the WithTimeout
+// option, this option will have no effect.
+// Also note that the passed frequency must be greater than zero or this option
+// will have no effect.
+func WithTimeoutUpdateFrequency(frequency int) TimeoutOptions {
+	return func(manager *TimeoutManager) {
+		if frequency > 0 {
+			manager.timeoutUpdateFrequency = frequency
+		}
+	}
+}
+
+// WithTMHandshakeTimeout is used to set the timeout used during the handshake.
+// If the timeout is reached without response from the peer then the handshake
+// will be aborted and restarted.
+func WithTMHandshakeTimeout(timeout time.Duration) TimeoutOptions {
+	return func(manager *TimeoutManager) {
+		manager.handshakeTimeout = timeout
+	}
+}
+
+// WithTMKeepalivePing is used to send a ping packet if no packets have been
+// received from the other side for the given duration. This helps keep the
+// connection alive and also ensures that the connection is closed if the
+// other side does not respond to the ping in a timely manner. After the ping
+// the connection will be closed if the other side does not respond within
+// time duration.
+func WithTMKeepalivePing(ping, pong time.Duration) TimeoutOptions {
+	return func(manager *TimeoutManager) {
+		manager.pingTime = ping
+		manager.pongTime = pong
+	}
+}
+
 // config holds the configuration values for an instance of GoBackNConn.
 type config struct {
 	// n is the window size. The sender can send a maximum of n packets

--- a/gbn/config.go
+++ b/gbn/config.go
@@ -66,6 +66,18 @@ func WithKeepalivePing(ping, pong time.Duration) TimeoutOptions {
 	}
 }
 
+// WithBoostPercent is used to set the boost percent that the timeout manager
+// will use to boost the resend timeout & handshake timeout every time a resend
+// is required due to not receiving a response within the current timeout.
+func WithBoostPercent(boostPercent float32) TimeoutOptions {
+	return func(manager *TimeoutManager) {
+		if boostPercent > 0 {
+			manager.resendBoostPercent = boostPercent
+			manager.handshakeBoostPercent = boostPercent
+		}
+	}
+}
+
 // config holds the configuration values for an instance of GoBackNConn.
 type config struct {
 	// n is the window size. The sender can send a maximum of n packets

--- a/gbn/gbn_client.go
+++ b/gbn/gbn_client.go
@@ -128,9 +128,11 @@ handshake:
 			default:
 			}
 
+			timeout := g.timeoutManager.GetHandshakeTimeout()
+
 			var b []byte
 			select {
-			case <-time.After(g.cfg.handshakeTimeout):
+			case <-time.After(timeout):
 				g.log.Debugf("SYN resendTimeout. Resending " +
 					"SYN.")
 

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -21,12 +21,7 @@ var (
 )
 
 const (
-	DefaultN                = 20
-	defaultHandshakeTimeout = 100 * time.Millisecond
-	defaultResendTimeout    = 100 * time.Millisecond
-	finSendTimeout          = 1000 * time.Millisecond
-	DefaultSendTimeout      = math.MaxInt64
-	DefaultRecvTimeout      = math.MaxInt64
+	DefaultN = 20
 )
 
 type sendBytesFunc func(ctx context.Context, b []byte) error
@@ -322,7 +317,7 @@ func (g *GoBackNConn) Close() error {
 			g.log.Tracef("Try sending FIN")
 
 			ctxc, cancel := context.WithTimeout(
-				g.ctx, finSendTimeout,
+				g.ctx, defaultFinSendTimeout,
 			)
 			defer cancel()
 			if err := g.sendPacket(ctxc, &PacketFIN{}); err != nil {

--- a/gbn/gbn_conn.go
+++ b/gbn/gbn_conn.go
@@ -83,7 +83,7 @@ func newGoBackNConn(ctx context.Context, cfg *config,
 	prefix := fmt.Sprintf("(%s)", loggerPrefix)
 	plog := build.NewPrefixLog(prefix, log)
 
-	timeoutManager := NewTimeOutManager(plog)
+	timeoutManager := NewTimeOutManager(plog, cfg.timeoutOptions...)
 
 	g := &GoBackNConn{
 		cfg:               cfg,

--- a/gbn/gbn_server.go
+++ b/gbn/gbn_server.go
@@ -143,7 +143,7 @@ func (g *GoBackNConn) serverHandshake() error { // nolint:gocyclo
 		}
 
 		select {
-		case <-time.After(g.cfg.handshakeTimeout):
+		case <-time.After(g.timeoutManager.GetHandshakeTimeout()):
 			g.log.Debugf("SYNCACK resendTimeout. Abort and wait " +
 				"for client to re-initiate")
 			continue

--- a/gbn/options.go
+++ b/gbn/options.go
@@ -1,7 +1,5 @@
 package gbn
 
-import "time"
-
 type Option func(conn *config)
 
 // WithMaxSendSize is used to set the maximum payload size in bytes per packet.
@@ -14,33 +12,11 @@ func WithMaxSendSize(size int) Option {
 	}
 }
 
-// WithTimeout is used to set the resend timeout. This is the time to wait
-// for ACKs before resending the queue.
-func WithTimeout(timeout time.Duration) Option {
+// WithTimeoutOptions is used to set the different timeout options that will be
+// used within gbn package.
+func WithTimeoutOptions(opts ...TimeoutOptions) Option {
 	return func(conn *config) {
-		conn.resendTimeout = timeout
-	}
-}
-
-// WithHandshakeTimeout is used to set the timeout used during the handshake.
-// If the timeout is reached without response from the peer then the handshake
-// will be aborted and restarted.
-func WithHandshakeTimeout(timeout time.Duration) Option {
-	return func(conn *config) {
-		conn.handshakeTimeout = timeout
-	}
-}
-
-// WithKeepalivePing is used to send a ping packet if no packets have been
-// received from the other side for the given duration. This helps keep the
-// connection alive and also ensures that the connection is closed if the
-// other side does not respond to the ping in a timely manner. After the ping
-// the connection will be closed if the other side does not respond within
-// time duration.
-func WithKeepalivePing(ping, pong time.Duration) Option {
-	return func(conn *config) {
-		conn.pingTime = ping
-		conn.pongTime = pong
+		conn.timeoutOptions = opts
 	}
 }
 

--- a/gbn/queue_test.go
+++ b/gbn/queue_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestQueueSize(t *testing.T) {
-	q := newQueue(&queueCfg{s: 4})
+	q := newQueue(&queueCfg{s: 4}, NewTimeOutManager(nil))
 
 	require.Equal(t, uint8(0), q.size())
 
@@ -33,16 +33,18 @@ func TestQueueResend(t *testing.T) {
 	resentPackets := make(map[uint8]struct{})
 	queueTimeout := time.Second * 1
 
+	tm := NewTimeOutManager(nil)
+	tm.resendTimeout = queueTimeout
+
 	cfg := &queueCfg{
-		s:       5,
-		timeout: queueTimeout,
+		s: 5,
 		sendPkt: func(packet *PacketData) error {
 			resentPackets[packet.Seq] = struct{}{}
 
 			return nil
 		},
 	}
-	q := newQueue(cfg)
+	q := newQueue(cfg, tm)
 
 	pkt1 := &PacketData{Seq: 1}
 	pkt2 := &PacketData{Seq: 2}

--- a/gbn/syncer_test.go
+++ b/gbn/syncer_test.go
@@ -19,7 +19,10 @@ func TestSyncer(t *testing.T) {
 	syncTimeout := time.Second * 1
 	expectedNACK := uint8(3)
 
-	syncer := newSyncer(5, nil, syncTimeout, make(chan struct{}))
+	tm := NewTimeOutManager(nil)
+	tm.resendTimeout = syncTimeout
+
+	syncer := newSyncer(5, nil, tm, make(chan struct{}))
 
 	// Let's first test the scenario where we don't receive the expected
 	// ACK/NACK after initiating the resend. This should trigger a timeout

--- a/gbn/timeout_manager.go
+++ b/gbn/timeout_manager.go
@@ -1,0 +1,356 @@
+package gbn
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btclog"
+)
+
+const (
+	defaultHandshakeTimeout       = 100 * time.Millisecond
+	defaultResendTimeout          = 100 * time.Millisecond
+	minimumResendTimeout          = 100 * time.Millisecond
+	defaultFinSendTimeout         = 1000 * time.Millisecond
+	defaultResendMultiplier       = 5
+	defaultTimeoutUpdateFrequency = 100
+	DefaultSendTimeout            = math.MaxInt64
+	DefaultRecvTimeout            = math.MaxInt64
+)
+
+// TimeoutManager manages the different timeouts used by the gbn package.
+type TimeoutManager struct {
+	// useStaticTimeout is used to indicate whether the resendTimeout
+	// has been manually set, and if so, should not be updated dynamically.
+	useStaticTimeout bool
+
+	// hasSetDynamicTimeout is used to indicate whether the resendTimeout
+	// has ever been set dynamically.
+	hasSetDynamicTimeout bool
+
+	// resendTimeout defines the current resend timeout used by the
+	// timeout manager.
+	// The resend timeout is the duration that will be waited before
+	// resending the packets in the current queue. The timeout is set
+	// dynamically, and is set to the time it took for the other party to
+	// respond, multiplied by the resendMultiplier.
+	resendTimeout time.Duration
+
+	// resendMultiplier defines the multiplier used when multiplying the
+	// duration it took for the other party to respond when setting the
+	// resendTimeout.
+	resendMultiplier int
+
+	// latestSentSYNTime is used to keep track of the time when the latest
+	// SYN message was sent. This is used to dynamically set the resend
+	// timeout, based on how long it took for the other party to respond to
+	// the SYN message.
+	latestSentSYNTime time.Time
+
+	// latestSentSYNTimeMu should be locked when updating or accessing the
+	// latestSentSYNTime field.
+	latestSentSYNTimeMu sync.Mutex
+
+	// handshakeTimeout is the time after which the server or client
+	// will abort and restart the handshake if the expected response is
+	// not received from the peer.
+	handshakeTimeout time.Duration
+
+	// finSendTimeout is the timeout after which the created context for
+	// sending a FIN message will be time out.
+	finSendTimeout time.Duration
+
+	// sendTimeout defines the max time we will wait to send a msg before
+	// timing out.
+	sendTimeout time.Duration
+
+	// recvTimeout defines the max time we will wait to receive a msg before
+	// timing out.
+	recvTimeout time.Duration
+
+	// pingTime represents at which frequency we will send pings to the
+	// counterparty if we've received no packet.
+	pingTime time.Duration
+
+	// pongTime represents how long we will wait for the expect a pong
+	// response after we've sent a ping. If no response is received within
+	// the time limit, we will close the connection.
+	pongTime time.Duration
+
+	// responseCounter represents the current number of corresponding
+	// responses received since last updating the resend timeout.
+	responseCounter int
+
+	// timeoutUpdateFrequency represents the frequency of how many
+	// corresponding responses we need to receive until the resend timeout
+	// will be updated.
+	timeoutUpdateFrequency int
+
+	log btclog.Logger
+
+	sentTimes   map[uint8]time.Time
+	sentTimesMu sync.Mutex
+
+	// mu should be locked when updating or accessing any of timeout
+	// manager's timeout fields. It should also be held when accessing any
+	// of the timeout manager's fields that get updated throughout the
+	// lifecycle of the timeout manager after initialization, that doesn't
+	// have a dedicated mutex.
+	//
+	// Note that the lock order for this mutex is before any of the other
+	// mutexes in the timeout manager.
+	mu sync.RWMutex
+}
+
+// NewTimeOutManager creates a new timeout manager.
+func NewTimeOutManager(logger btclog.Logger,
+	timeoutOpts ...TimeoutOptions) *TimeoutManager {
+
+	if logger == nil {
+		logger = log
+	}
+
+	m := &TimeoutManager{
+		log:                    logger,
+		resendTimeout:          defaultResendTimeout,
+		handshakeTimeout:       defaultHandshakeTimeout,
+		useStaticTimeout:       false,
+		resendMultiplier:       defaultResendMultiplier,
+		finSendTimeout:         defaultFinSendTimeout,
+		recvTimeout:            DefaultRecvTimeout,
+		sendTimeout:            DefaultSendTimeout,
+		sentTimes:              make(map[uint8]time.Time),
+		timeoutUpdateFrequency: defaultTimeoutUpdateFrequency,
+	}
+
+	for _, opt := range timeoutOpts {
+		opt(m)
+	}
+
+	return m
+}
+
+// Sent should be called when a message is sent by the connection. The resent
+// parameter should be set to true if the message is a resent message.
+func (m *TimeoutManager) Sent(msg Message, resent bool) {
+	if m.useStaticTimeout {
+		return
+	}
+
+	sentAt := time.Now()
+
+	// We will dynamically update the resend timeout throughout the lifetime
+	// of the connection, to ensure that it reflects the current response
+	// time. Therefore, we'll keep track of when we sent a package, and when
+	// we receive the corresponding response.
+	// If we're resending a message, we can't know if a corresponding
+	// response is the response to the resent message, or the original
+	// message. Therefore, we never update the resend timeout after
+	// resending a message.
+	switch msg := msg.(type) {
+	case *PacketSYN:
+		m.latestSentSYNTimeMu.Lock()
+		defer m.latestSentSYNTimeMu.Unlock()
+
+		if !resent {
+			m.latestSentSYNTime = sentAt
+
+			return
+		}
+
+		// If we've resent the SYN, we'll reset the latestSentSYNTime to
+		// the zero value, to ensure that we don't update the resend
+		// timeout based on the corresponding response, as we can't know
+		// if the response is for the resent SYN or the original SYN.
+		m.latestSentSYNTime = time.Time{}
+
+	case *PacketData:
+		m.sentTimesMu.Lock()
+		defer m.sentTimesMu.Unlock()
+
+		if resent {
+			// If we're resending a data packet, we'll delete the
+			// sent time for the sequence, to ensure that we won't
+			// update the resend timeout when we receive the
+			// corresponding response.
+			delete(m.sentTimes, msg.Seq)
+
+			return
+		}
+
+		m.sentTimes[msg.Seq] = sentAt
+	}
+}
+
+// Received should be called when a message is received by the connection.
+func (m *TimeoutManager) Received(msg Message) {
+	if m.useStaticTimeout {
+		return
+	}
+
+	receivedAt := time.Now()
+
+	// We lock the TimeoutManager's mu as soon as Received is executed, to
+	// ensure that any GetResendTimeout call we receive concurrently after
+	// this Received call, will return an updated resend timeout if this
+	// Received call does update the timeout.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch msg := msg.(type) {
+	case *PacketSYN, *PacketSYNACK:
+		m.latestSentSYNTimeMu.Lock()
+
+		if m.latestSentSYNTime.IsZero() {
+			m.latestSentSYNTimeMu.Unlock()
+
+			return
+		}
+
+		responseTime := receivedAt.Sub(m.latestSentSYNTime)
+
+		m.latestSentSYNTime = time.Time{}
+
+		m.latestSentSYNTimeMu.Unlock()
+
+		m.updateResendTimeoutUnsafe(responseTime)
+
+	case *PacketACK:
+		m.sentTimesMu.Lock()
+
+		sentTime, ok := m.sentTimes[msg.Seq]
+		if !ok {
+			m.sentTimesMu.Unlock()
+
+			return
+		}
+
+		delete(m.sentTimes, msg.Seq)
+
+		m.sentTimesMu.Unlock()
+
+		m.responseCounter++
+
+		reachedFrequency := m.responseCounter%
+			m.timeoutUpdateFrequency == 0
+
+		// In case we never set the resend timeout dynamically in the
+		// handshake due to needing to resend the SYN, or if we've
+		// reached received the number of packages matching the
+		// timeoutUpdateFrequency, we'll update the resend timeout.
+		if !m.hasSetDynamicTimeout || reachedFrequency {
+			m.responseCounter = 0
+
+			m.updateResendTimeoutUnsafe(receivedAt.Sub(sentTime))
+		}
+	}
+}
+
+// updateResendTimeout updates the resend timeout based on the given response
+// time. The resend timeout will be only be updated if the given response time
+// is greater than the default resend timeout, after being multiplied by the
+// resendMultiplier.
+//
+// NOTE: This function TimeoutManager mu must be held when calling this
+// function.
+func (m *TimeoutManager) updateResendTimeoutUnsafe(responseTime time.Duration) {
+	m.hasSetDynamicTimeout = true
+
+	multipliedTimeout := time.Duration(m.resendMultiplier) * responseTime
+
+	if multipliedTimeout < minimumResendTimeout {
+		m.log.Tracef("Setting resendTimeout to minimumResendTimeout "+
+			"%v as the new dynamic timeout %v is not greater than "+
+			"the minimum resendTimeout.",
+			m.resendTimeout, multipliedTimeout)
+		multipliedTimeout = minimumResendTimeout
+	}
+
+	m.log.Tracef("Updating resendTimeout to %v", multipliedTimeout)
+
+	m.resendTimeout = multipliedTimeout
+}
+
+// GetResendTimeout returns the current resend timeout.
+func (m *TimeoutManager) GetResendTimeout() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.resendTimeout
+}
+
+// GetHandshakeTimeout returns the handshake timeout.
+func (m *TimeoutManager) GetHandshakeTimeout() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.handshakeTimeout
+}
+
+// GetFinSendTimeout returns the fin send timeout.
+func (m *TimeoutManager) GetFinSendTimeout() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.finSendTimeout
+}
+
+// GetSendTimeout returns the send timeout.
+func (m *TimeoutManager) GetSendTimeout() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.sendTimeout
+}
+
+// GetRecvTimeout returns the recv timeout.
+func (m *TimeoutManager) GetRecvTimeout() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.recvTimeout
+}
+
+// GetPingTime returns the ping time, representing at which frequency we will
+// send pings to the counterparty if we've received no packet.
+func (m *TimeoutManager) GetPingTime() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.pingTime == 0 {
+		return time.Duration(math.MaxInt64)
+	}
+
+	return m.pingTime
+}
+
+// GetPongTime returns the pong timeout, representing how long we will wait for
+// the expect a pong response after we've sent a ping. If no response is
+// received within the time limit, we will close the connection.
+func (m *TimeoutManager) GetPongTime() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.pongTime == 0 {
+		return time.Duration(math.MaxInt64)
+	}
+
+	return m.pongTime
+}
+
+// SetSendTimeout sets the send timeout.
+func (m *TimeoutManager) SetSendTimeout(timeout time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.sendTimeout = timeout
+}
+
+// SetRecvTimeout sets the receive timeout.
+func (m *TimeoutManager) SetRecvTimeout(timeout time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.recvTimeout = timeout
+}

--- a/gbn/timeout_manager.go
+++ b/gbn/timeout_manager.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	defaultHandshakeTimeout       = 100 * time.Millisecond
-	defaultResendTimeout          = 100 * time.Millisecond
-	minimumResendTimeout          = 100 * time.Millisecond
+	defaultHandshakeTimeout       = 1000 * time.Millisecond
+	defaultResendTimeout          = 1000 * time.Millisecond
+	minimumResendTimeout          = 1000 * time.Millisecond
 	defaultFinSendTimeout         = 1000 * time.Millisecond
 	defaultResendMultiplier       = 5
 	defaultTimeoutUpdateFrequency = 100

--- a/gbn/timeout_manager_test.go
+++ b/gbn/timeout_manager_test.go
@@ -1,0 +1,262 @@
+package gbn
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkTimeoutMgrSynchronously benchmarks the timeout manager when sending
+// and receiving messages synchronously.
+func BenchmarkTimeoutMgrSynchronously(b *testing.B) {
+	// Create a new timeout manager to use for the test. We set the timeout
+	// update frequency 2, so that the resend timeout is dynamically set
+	// every other message.
+	tm := NewTimeOutManager(nil, WithTimeoutUpdateFrequency(2))
+
+	for n := 0; n < b.N; n++ {
+		msg := &PacketData{Seq: uint8(n)}
+
+		tm.Sent(msg, false)
+		tm.Received(msg)
+	}
+}
+
+// BenchmarkTimeoutMgrConcurrently benchmarks the timeout manager when sending
+// and receiving messages concurrently.
+func BenchmarkTimeoutMgrConcurrently(b *testing.B) {
+	// Create a new timeout manager to use for the test. We set the timeout
+	// update frequency 2, so that the resend timeout is dynamically set
+	// every other message.
+	tm := NewTimeOutManager(nil, WithTimeoutUpdateFrequency(2))
+
+	var wg sync.WaitGroup
+	for n := 0; n < b.N; n++ {
+		wg.Add(1)
+		go func(seq uint8) {
+			defer wg.Done()
+
+			msg := &PacketData{Seq: seq}
+
+			tm.Sent(msg, false)
+			tm.Received(msg)
+		}(uint8(n))
+	}
+
+	wg.Wait()
+}
+
+// TestStressTestTimeoutMgr tests that the timeout manager can handle a large
+// number of concurrent Sent & Received calls, to ensure that the functions does
+// not cause any deadlocks.
+func TestStressTestTimeoutMgr(t *testing.T) {
+	t.Parallel()
+
+	tm := NewTimeOutManager(nil, WithTimeoutUpdateFrequency(2))
+
+	var wg sync.WaitGroup
+	for n := 0; n < 100000; n++ {
+		wg.Add(1)
+		go func(seq uint8) {
+			defer wg.Done()
+
+			msg := &PacketData{Seq: seq}
+
+			tm.Sent(msg, false)
+			tm.Received(msg)
+		}(uint8(n))
+	}
+
+	wg.Wait()
+}
+
+// TestDynamicTimeout ensures that the resend timeout is dynamically set as
+// expected in the timeout manager, with the SYN message that's sent with the
+// handshake.
+func TestSYNDynamicTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Create a new timeout manager to use for the test.
+	tm := NewTimeOutManager(nil)
+
+	// First, we'll ensure that the resend timeout doesn't change if we
+	// don't send and receive messages.
+	noResendTimeoutChange(t, tm, time.Second)
+
+	// Next, we'll simulate that a SYN message has been sent and received.
+	// This should change the resend timeout given that the new timeout is
+	// greater than the minimum allowed timeout.
+	initialResendTimeout := tm.GetResendTimeout()
+
+	synMsg := &PacketSYN{N: 20}
+
+	sendAndReceive(t, tm, synMsg, synMsg, false)
+
+	// The resend timeout should now have dynamically changed. Since the
+	// sendAndReceive function waits for one second before simulating the
+	// response, execution of the function must have more than 1 sec.
+	// We are then sure that the resend timeout has been dynamically
+	// set to a value greater default 1 second resend timeout.
+	resendTimeout := tm.GetResendTimeout()
+	require.Greater(t, resendTimeout, initialResendTimeout)
+
+	// Let's also test that the resend timeout is dynamically set to the
+	// expected value, and that the resend multiplier works as expected. If
+	// we set the resend multiplier to 10, then send and receive a response
+	// after 1 second, then the resend timeout should be around 10 seconds.
+	tm.resendMultiplier = 10
+
+	sendAndReceive(t, tm, synMsg, synMsg, false)
+
+	// As it takes a short amount of time to simulate the send and receive
+	// of the message, we'll accept a set resend timeout within a range of
+	// 10-11 seconds as correct.
+	resendTimeout = tm.GetResendTimeout()
+	require.InDelta(t, time.Second*10, resendTimeout, float64(time.Second))
+
+	// We'll also test that the resend timeout isn't dynamically set if
+	// the new timeout is less than the minimum allowed resend timeout.
+	tm.resendMultiplier = 1
+
+	sendAndReceiveWithDuration(
+		t, tm, minimumResendTimeout/10, synMsg, synMsg, false,
+	)
+
+	newTimeout := tm.GetResendTimeout()
+	require.Equal(t, minimumResendTimeout, newTimeout)
+
+	// Then we'll test that the resend timeout isn't dynamically set if
+	// when simulating a that the SYN message has been resent.
+	sendAndReceive(t, tm, synMsg, synMsg, true)
+
+	unchangedResendTimeout := tm.GetResendTimeout()
+	require.Equal(t, newTimeout, unchangedResendTimeout)
+}
+
+// TestDataPackageDynamicTimeout ensures that the resend timeout is dynamically
+// set as expected in the timeout manager, when PacketData messages and their
+// corresponding response are exchanged between the counterparties.
+func TestDataPackageDynamicTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Create a new timeout manager to use for the test. We set the timeout
+	// update frequency to a high value so that we're sure that it's not the
+	// reason for the first the resend timeout change.
+	tm := NewTimeOutManager(nil, WithTimeoutUpdateFrequency(1000))
+
+	// Next, we'll simulate that a data packet has been sent and received.
+	// This should change the resend timeout despite the timeout update
+	// frequency being set to a high value, as we never set the resend
+	// timeout with in the handshake with by a SYN msg + response.
+	initialResendTimeout := tm.GetResendTimeout()
+
+	msg := &PacketData{Seq: 20}
+	response := &PacketACK{Seq: 20}
+
+	sendAndReceive(t, tm, msg, response, false)
+
+	// The resend timeout should now have dynamically changed.
+	resendTimeout := tm.GetResendTimeout()
+	require.NotEqual(t, initialResendTimeout, resendTimeout)
+
+	// Now let's test that the timeout update frequency works as expected.
+	// If we set it to 2, we should only update the resend timeout on the
+	// second data packet send + receive (as the receive counter in the
+	// timeout manager was just reset above when setting the resend
+	// timeout).
+	tm.timeoutUpdateFrequency = 2
+
+	// We set resend multiplier to a high value, to ensure that the resend
+	// timeout is guaranteed to be set to a greater value then the previous
+	// resend timeout.
+	tm.resendMultiplier = 10
+
+	// The first send and receive should not change the resend timeout.
+	sendAndReceive(t, tm, msg, response, false)
+
+	unchangedResendTimeout := tm.GetResendTimeout()
+	require.Equal(t, resendTimeout, unchangedResendTimeout)
+
+	// The second send and receive should however change the resend timeout.
+	sendAndReceive(t, tm, msg, response, false)
+
+	newResendTimeout := tm.GetResendTimeout()
+	require.NotEqual(t, resendTimeout, newResendTimeout)
+
+	// Finally let's test that the resend timeout isn't dynamically set when
+	// simulating that the data packet has been resent.
+	tm.timeoutUpdateFrequency = 1
+	tm.resendMultiplier = 100
+
+	sendAndReceive(t, tm, msg, response, true)
+
+	unchangedResendTimeout = tm.GetResendTimeout()
+	require.Equal(t, newResendTimeout, unchangedResendTimeout)
+}
+
+// TestStaticTimeout ensures that the resend timeout isn't dynamically set if a
+// static timeout has been set.
+func TestStaticTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Create a new timeout manager with a set static resend timeout to use
+	// for the test.
+	staticTimeout := time.Second * 2
+	tm := NewTimeOutManager(nil, WithStaticResendTimeout(staticTimeout))
+
+	synMsg := &PacketSYN{N: 20}
+
+	// Then ensure that the resend timeout isn't dynamically set if we send
+	// and receive messages after setting a static timeout.
+	sendAndReceive(t, tm, synMsg, synMsg, false)
+
+	resendTimeout := tm.GetResendTimeout()
+	require.Equal(t, staticTimeout, resendTimeout)
+}
+
+// sendAndReceive simulates that a SYN message has been sent for the passed the
+// timeout manager, and then waits for one second before a simulating the SYN
+// response. While waiting, the function asserts that the resend timeout hasn't
+// changed.
+func sendAndReceive(t *testing.T, tm *TimeoutManager, msg Message,
+	response Message, resent bool) {
+
+	t.Helper()
+
+	sendAndReceiveWithDuration(t, tm, time.Second, msg, response, resent)
+}
+
+// sendAndReceive simulates that a SYN message has been sent for the passed the
+// timeout manager, and then waits for specified delay before a simulating the
+// SYN response. While waiting, the function asserts that the resend timeout
+// hasn't changed.
+func sendAndReceiveWithDuration(t *testing.T, tm *TimeoutManager,
+	responseDelay time.Duration, msg Message, response Message,
+	resent bool) {
+
+	t.Helper()
+
+	tm.Sent(msg, resent)
+
+	noResendTimeoutChange(t, tm, responseDelay)
+
+	tm.Received(response)
+}
+
+// noResendTimeoutChange asserts that the resend timeout hasn't changed for the
+// passed timeout manager for the specified duration.
+func noResendTimeoutChange(t *testing.T, tm *TimeoutManager,
+	duration time.Duration) {
+
+	t.Helper()
+
+	resendTimeout := tm.GetResendTimeout()
+
+	err := wait.Invariant(func() bool {
+		return resendTimeout == tm.GetResendTimeout()
+	}, duration)
+	require.NoError(t, err)
+}

--- a/itest/client_harness.go
+++ b/itest/client_harness.go
@@ -119,6 +119,10 @@ func (c *clientHarness) start() error {
 }
 
 func (c *clientHarness) cleanup() error {
-	c.cancel()
+	// We cancel the context after closing the connection, as it's used
+	// during the connection closing process. We defer the cancel to make
+	// sure it's always canceled.
+	defer c.cancel()
+
 	return c.grpcConn.Close()
 }

--- a/itest/connection_test.go
+++ b/itest/connection_test.go
@@ -15,7 +15,7 @@ var (
 	defaultMessage = []byte("some default message")
 )
 
-const defaultTimeout = 30 * time.Second
+const defaultTimeout = 60 * time.Second
 
 // testHappyPath ensures that client and server are able to communicate
 // as expected in the case where no connections are dropped.

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -166,10 +166,12 @@ func NewClientConn(ctx context.Context, sid [64]byte, serverHost string,
 	}
 
 	c.gbnOptions = []gbn.Option{
-		gbn.WithTimeout(gbnTimeout),
-		gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
-		gbn.WithKeepalivePing(
-			gbnClientPingTimeout, gbnPongTimeout,
+		gbn.WithTimeoutOptions(
+			gbn.WithStaticResendTimeout(gbnTimeout),
+			gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
+			gbn.WithKeepalivePing(
+				gbnClientPingTimeout, gbnPongTimeout,
+			),
 		),
 		gbn.WithOnFIN(func() {
 			// We force the connection to set a new status after

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -82,6 +82,12 @@ const (
 	// gbnPongTimout is the time after sending the pong message that we will
 	// timeout if we do not receive any message from our peer.
 	gbnPongTimeout = 3 * time.Second
+
+	// gbnBoostPercent is the percentage value that the resend and handshake
+	// timeout will be boosted any time we need to resend a packet due to
+	// the corresponding response not being received within the previous
+	// timeout.
+	gbnBoostPercent = 0.5
 )
 
 // ClientStatus is a description of the connection status of the client.
@@ -183,6 +189,7 @@ func NewClientConn(ctx context.Context, sid [64]byte, serverHost string,
 			gbn.WithKeepalivePing(
 				gbnClientPingTimeout, gbnPongTimeout,
 			),
+			gbn.WithBoostPercent(gbnBoostPercent),
 		),
 		gbn.WithOnFIN(func() {
 			// We force the connection to set a new status after

--- a/mailbox/client_conn.go
+++ b/mailbox/client_conn.go
@@ -46,6 +46,14 @@ const (
 	// to receive ACKS from the peer before resending the queue.
 	gbnTimeout = 1000 * time.Millisecond
 
+	// gbnResendMultiplier is the multiplier that we want the gbn
+	// connection to use when dynamically setting the resend timeout.
+	gbnResendMultiplier = 5
+
+	// gbnTimeoutUpdateFrequency is the frequency representing the number of
+	// packages + responses we want, before we update the resend timeout.
+	gbnTimeoutUpdateFrequency = 200
+
 	// gbnN is the queue size, N, that the gbn server will use. The gbn
 	// server will send up to N packets before requiring an ACK for the
 	// first packet in the queue.
@@ -167,7 +175,10 @@ func NewClientConn(ctx context.Context, sid [64]byte, serverHost string,
 
 	c.gbnOptions = []gbn.Option{
 		gbn.WithTimeoutOptions(
-			gbn.WithStaticResendTimeout(gbnTimeout),
+			gbn.WithResendMultiplier(gbnResendMultiplier),
+			gbn.WithTimeoutUpdateFrequency(
+				gbnTimeoutUpdateFrequency,
+			),
 			gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
 			gbn.WithKeepalivePing(
 				gbnClientPingTimeout, gbnPongTimeout,

--- a/mailbox/server_conn.go
+++ b/mailbox/server_conn.go
@@ -81,7 +81,10 @@ func NewServerConn(ctx context.Context, serverHost string,
 		quit:   make(chan struct{}),
 		gbnOptions: []gbn.Option{
 			gbn.WithTimeoutOptions(
-				gbn.WithStaticResendTimeout(gbnTimeout),
+				gbn.WithResendMultiplier(gbnResendMultiplier),
+				gbn.WithTimeoutUpdateFrequency(
+					gbnTimeoutUpdateFrequency,
+				),
 				gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
 				gbn.WithKeepalivePing(
 					gbnServerPingTimeout, gbnPongTimeout,

--- a/mailbox/server_conn.go
+++ b/mailbox/server_conn.go
@@ -89,6 +89,7 @@ func NewServerConn(ctx context.Context, serverHost string,
 				gbn.WithKeepalivePing(
 					gbnServerPingTimeout, gbnPongTimeout,
 				),
+				gbn.WithBoostPercent(gbnBoostPercent),
 			),
 		},
 		status:      ServerStatusNotConnected,

--- a/mailbox/server_conn.go
+++ b/mailbox/server_conn.go
@@ -80,10 +80,12 @@ func NewServerConn(ctx context.Context, serverHost string,
 		cancel: cancel,
 		quit:   make(chan struct{}),
 		gbnOptions: []gbn.Option{
-			gbn.WithTimeout(gbnTimeout),
-			gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
-			gbn.WithKeepalivePing(
-				gbnServerPingTimeout, gbnPongTimeout,
+			gbn.WithTimeoutOptions(
+				gbn.WithStaticResendTimeout(gbnTimeout),
+				gbn.WithHandshakeTimeout(gbnHandshakeTimeout),
+				gbn.WithKeepalivePing(
+					gbnServerPingTimeout, gbnPongTimeout,
+				),
 			),
 		},
 		status:      ServerStatusNotConnected,


### PR DESCRIPTION
Based on #87

This PR updates the resend timeout to be dynamically set based on how long it took for the other party to respond during the handshake process.
The timeout is set to the time it took for the server to respond multiplied by the resendMultiplier, unless the duration is shorter than the default resend timeout. If the the resend timeout has been manually set, the resend timeout will always be set to that value, and won't be dynamically set.

Prior to this PR, the timeout before a client resends the queue of packets was always a fixed value. This fixed timeout isn't suitable for all clients as the latency for different clients varies.