### PR TITLE
gbn+mailbox: cleanup & prefixed logger

### DIFF
--- a/gbn/config.go
+++ b/gbn/config.go
@@ -1,0 +1,62 @@
+package gbn
+
+import "time"
+
+// config holds the configuration values for an instance of GoBackNConn.
+type config struct {
+	// n is the window size. The sender can send a maximum of n packets
+	// before requiring an ack from the receiver for the first packet in
+	// the window. The value of n is chosen by the client during the
+	// GoBN handshake.
+	n uint8
+
+	// s is the maximum sequence number used to label packets. Packets
+	// are labelled with incrementing sequence numbers modulo s.
+	// s must be strictly larger than the window size, n. This
+	// is so that the receiver can tell if the sender is resending the
+	// previous window (maybe the sender did not receive the acks) or if
+	// they are sending the next window. If s <= n then there would be
+	// no way to tell.
+	s uint8
+
+	// maxChunkSize is the maximum payload size in bytes allowed per
+	// message. If the payload to be sent is larger than maxChunkSize then
+	// the payload will be split between multiple packets.
+	// If maxChunkSize is zero then it is disabled and data won't be split
+	// between packets.
+	maxChunkSize int
+
+	// resendTimeout is the duration that will be waited before resending
+	// the packets in the current queue.
+	resendTimeout time.Duration
+
+	// recvFromStream is the function that will be used to acquire the next
+	// available packet.
+	recvFromStream recvBytesFunc
+
+	// sendToStream is the function that will be used to send over our next
+	// packet.
+	sendToStream sendBytesFunc
+
+	// handshakeTimeout is the time after which the server or client
+	// will abort and restart the handshake if the expected response is
+	// not received from the peer.
+	handshakeTimeout time.Duration
+
+	pingTime time.Duration
+	pongTime time.Duration
+}
+
+// newConfig constructs a new config struct.
+func newConfig(sendFunc sendBytesFunc, recvFunc recvBytesFunc,
+	n uint8) *config {
+
+	return &config{
+		n:                n,
+		s:                n + 1,
+		recvFromStream:   recvFunc,
+		sendToStream:     sendFunc,
+		resendTimeout:    defaultResendTimeout,
+		handshakeTimeout: defaultHandshakeTimeout,
+	}
+}

--- a/gbn/gbn_client.go
+++ b/gbn/gbn_client.go
@@ -108,14 +108,15 @@ handshake:
 		}
 
 		// Send SYN
-		log.Debugf("Client sending SYN")
+		g.log.Debugf("Sending SYN")
 		if err := g.sendToStream(g.ctx, msgBytes); err != nil {
 			return err
 		}
 
 		for {
 			// Wait for SYN
-			log.Debugf("Client waiting for SYN")
+			g.log.Debugf("Waiting for SYN")
+
 			select {
 			case recvNext <- 1:
 			case <-g.quit:
@@ -128,7 +129,9 @@ handshake:
 			var b []byte
 			select {
 			case <-time.After(g.handshakeTimeout):
-				log.Debugf("SYN resendTimeout. Resending SYN.")
+				g.log.Debugf("SYN resendTimeout. Resending " +
+					"SYN.")
+
 				continue handshake
 			case <-g.quit:
 				return nil
@@ -144,7 +147,8 @@ handshake:
 				return err
 			}
 
-			log.Debugf("Client got %T", resp)
+			g.log.Debugf("Got %T", resp)
+
 			switch r := resp.(type) {
 			case *PacketSYN:
 				respSYN = r
@@ -159,14 +163,14 @@ handshake:
 		}
 	}
 
-	log.Debugf("Client got SYN")
+	g.log.Debugf("Got SYN")
 
 	if respSYN.N != g.n {
 		return io.EOF
 	}
 
 	// Send SYNACK
-	log.Debugf("Client sending SYNACK")
+	g.log.Debugf("Sending SYNACK")
 	synack, err := new(PacketSYNACK).Serialize()
 	if err != nil {
 		return err
@@ -176,7 +180,7 @@ handshake:
 		return err
 	}
 
-	log.Debugf("Client Handshake complete")
+	g.log.Debugf("Handshake complete")
 
 	return nil
 }

--- a/gbn/options.go
+++ b/gbn/options.go
@@ -2,14 +2,14 @@ package gbn
 
 import "time"
 
-type Option func(conn *GoBackNConn)
+type Option func(conn *config)
 
 // WithMaxSendSize is used to set the maximum payload size in bytes per packet.
 // If set and a large payload comes through then it will be split up into
 // multiple packets with payloads no larger than the given maximum size.
 // A size of zero will disable splitting.
 func WithMaxSendSize(size int) Option {
-	return func(conn *GoBackNConn) {
+	return func(conn *config) {
 		conn.maxChunkSize = size
 	}
 }
@@ -17,7 +17,7 @@ func WithMaxSendSize(size int) Option {
 // WithTimeout is used to set the resend timeout. This is the time to wait
 // for ACKs before resending the queue.
 func WithTimeout(timeout time.Duration) Option {
-	return func(conn *GoBackNConn) {
+	return func(conn *config) {
 		conn.resendTimeout = timeout
 	}
 }
@@ -26,7 +26,7 @@ func WithTimeout(timeout time.Duration) Option {
 // If the timeout is reached without response from the peer then the handshake
 // will be aborted and restarted.
 func WithHandshakeTimeout(timeout time.Duration) Option {
-	return func(conn *GoBackNConn) {
+	return func(conn *config) {
 		conn.handshakeTimeout = timeout
 	}
 }
@@ -38,9 +38,8 @@ func WithHandshakeTimeout(timeout time.Duration) Option {
 // the connection will be closed if the other side does not respond within
 // time duration.
 func WithKeepalivePing(ping, pong time.Duration) Option {
-	return func(conn *GoBackNConn) {
+	return func(conn *config) {
 		conn.pingTime = ping
 		conn.pongTime = pong
-		conn.pongWait = make(chan struct{}, 1)
 	}
 }

--- a/gbn/queue_test.go
+++ b/gbn/queue_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestQueueSize(t *testing.T) {
-	q := newQueue(4, 0)
+	q := newQueue(4, 0, nil)
 
 	require.Equal(t, uint8(0), q.size())
 

--- a/mailbox/log.go
+++ b/mailbox/log.go
@@ -1,6 +1,8 @@
 package mailbox
 
 import (
+	"fmt"
+
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
 	"google.golang.org/grpc/grpclog"
@@ -27,6 +29,17 @@ func init() {
 // using btclog.
 func UseLogger(logger btclog.Logger) {
 	log = logger
+}
+
+// nePrefixedLogger constructs a new prefixed logger.
+func newPrefixedLogger(isServer bool) *build.PrefixLog {
+	identifier := "client"
+	if isServer {
+		identifier = "server"
+	}
+	prefix := fmt.Sprintf("(%s)", identifier)
+
+	return build.NewPrefixLog(prefix, log)
 }
 
 // GrpcLogLogger is a wrapper around a btclog logger to make it compatible with


### PR DESCRIPTION
This PR introduces a prefixed logger which is then passed to the client and server so that
their logs are prefixed with `(client)` and `(server)` so that we dont have to manually use
the `isServer` variable in logs. 

Then, some variables are moved out of the GBN struct and into a new `config` struct.

depends on #92