### PR TITLE
Fix WASM-client disconnection error

### DIFF
--- a/cmd/wasm-client/log.go
+++ b/cmd/wasm-client/log.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"github.com/btcsuite/btclog"
+	"github.com/lightninglabs/lightning-node-connect/gbn"
 	"github.com/lightninglabs/lightning-node-connect/mailbox"
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/build"
@@ -25,6 +26,7 @@ func SetupLoggers(root *build.RotatingLogWriter, intercept signal.Interceptor) {
 
 	lnd.SetSubLogger(root, Subsystem, log)
 	lnd.AddSubLogger(root, mailbox.Subsystem, intercept, mailbox.UseLogger)
+	lnd.AddSubLogger(root, gbn.Subsystem, intercept, gbn.UseLogger)
 
 	grpclog.SetLoggerV2(NewGrpcLogLogger(root, intercept, "GRPC"))
 }

--- a/example/index.html
+++ b/example/index.html
@@ -98,8 +98,10 @@ Add the following polyfill for Microsoft Edge 17/18 support:
     }
 
     async function disconnect() {
-        window[namespace].wasmClientDisconnect();
+        window[namespace].wasmClientDisconnect(onDisconnect);
+    }
 
+    function onDisconnect() {
         document.getElementById('disconnectBtn').disabled = true;
         document.getElementById('reconnectBtn').disabled = false;
         document.getElementById('ready').style.display= 'none' ;


### PR DESCRIPTION
In this PR, we add a fix that solves the error that the wasm-client freezes when attempting to close the sockets when disconnecting.

I've also added a commit to add the `gbn` subsystem to the wasm-client's logger. This simplifies debugging errors quite a lot. Let me know if you don't think that commit is worth including though :) 