### PR TITLE
gbn: make logger more informative in `debug` level

### DIFF
--- a/gbn/queue.go
+++ b/gbn/queue.go
@@ -136,7 +136,7 @@ func (q *queue) resend() error {
 	// Prepare the queue for awaiting the resend catch up.
 	q.syncer.initResendUpTo(top)
 
-	q.cfg.log.Tracef("Resending the queue")
+	q.cfg.log.Debugf("Resending the packets queue")
 
 	for base != top {
 		packet := q.content[base]

--- a/gbn/syncer.go
+++ b/gbn/syncer.go
@@ -208,12 +208,12 @@ func (c *syncer) waitForSync() {
 		return
 
 	case <-c.cancel:
-		c.log.Tracef("sync canceled or reset")
+		c.log.Debugf("Sync completed")
 
 	case <-time.After(
 		c.timeoutManager.GetResendTimeout() * awaitingTimeoutMultiplier,
 	):
-		c.log.Tracef("Timed out while waiting for sync")
+		c.log.Debugf("Timed out while waiting for sync")
 	}
 
 	c.reset()

--- a/gbn/timeout_manager.go
+++ b/gbn/timeout_manager.go
@@ -306,6 +306,8 @@ func (m *TimeoutManager) Sent(msg Message, resent bool) {
 		// we're resending the SYN message. This might occur multiple
 		// times until we receive the corresponding response.
 		m.handshakeBooster.Boost()
+		m.log.Debugf("Boosted handshakeTimeout to %v",
+			m.handshakeBooster.GetCurrentTimeout())
 
 	case *PacketData:
 		m.sentTimesMu.Lock()
@@ -319,6 +321,8 @@ func (m *TimeoutManager) Sent(msg Message, resent bool) {
 			delete(m.sentTimes, msg.Seq)
 
 			m.resendBooster.Boost()
+			m.log.Debugf("Boosted resendTimeout to %v",
+				m.resendBooster.GetCurrentTimeout())
 
 			return
 		}
@@ -411,7 +415,7 @@ func (m *TimeoutManager) updateResendTimeoutUnsafe(responseTime time.Duration) {
 		multipliedTimeout = minimumResendTimeout
 	}
 
-	m.log.Tracef("Updating resendTimeout to %v", multipliedTimeout)
+	m.log.Debugf("Updating resendTimeout to %v", multipliedTimeout)
 
 	m.resendTimeout = multipliedTimeout
 
@@ -428,8 +432,6 @@ func (m *TimeoutManager) GetResendTimeout() time.Duration {
 
 	resendTimeout := m.resendBooster.GetCurrentTimeout()
 
-	m.log.Debugf("Returning resendTimeout %v", resendTimeout)
-
 	return resendTimeout
 }
 
@@ -439,8 +441,6 @@ func (m *TimeoutManager) GetHandshakeTimeout() time.Duration {
 	defer m.mu.RUnlock()
 
 	handshake := m.handshakeBooster.GetCurrentTimeout()
-
-	m.log.Debugf("Returning handshakeTimeout %v", handshake)
 
 	return handshake
 }


### PR DESCRIPTION
This PR makes the logger more informative in `debug` level for the gbn packet, and also way less verbose as it won't log the current `resendTimeout` `handshakeTimeout` when the values are fetched, but instead when they are set.

The logger is also updated to inform when packets are resent even under `debug` log level.